### PR TITLE
Improve timeline navigation on mobile

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/Resume.css
+++ b/Resume.css
@@ -1,5 +1,162 @@
-body{
+body {
   background-color: white;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* Simplified vertical timeline */
+.vertical-timeline {
+  position: relative;
+  max-width: 700px;
+  margin: 40px auto;
+  padding-left: 60px;
+  height: 90vh;
+  overflow: hidden;
+}
+
+.vertical-timeline .timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+}
+
+
+
+.vertical-timeline .timeline-item {
+  position: relative;
+  margin: 0;
+  height: auto;
+  scroll-snap-align: start;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.vertical-timeline .timeline-item.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.timeline-indicator {
+  position: absolute;
+  top: 50%;
+  left: 20px;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.indicator-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  background: transparent;
+  position: relative;
+  cursor: pointer;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.indicator-dot::after {
+  content: attr(data-date);
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.3s;
+  pointer-events: none;
+}
+
+.indicator-dot.active {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.indicator-dot.active::after,
+.indicator-dot:hover::after {
+  opacity: 1;
+}
+
+
+.vertical-timeline .timeline-card {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  width: calc(100% - 2rem);
+  margin: 0 auto;
+}
+
+.vertical-timeline .timeline-card h3 {
+  margin-top: 0;
+  color: #01565b;
+}
+
+.vertical-timeline .job-meta {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.vertical-timeline .timeline-date-mobile {
+  display: none;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+@media (max-width: 768px) {
+  .vertical-timeline {
+    padding-left: 40px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  .vertical-timeline .timeline-list {
+    height: auto;
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+  }
+
+  .vertical-timeline .timeline-item {
+    height: auto;
+  }
+
+  .timeline-indicator {
+    left: 15px;
+  }
+
+  .vertical-timeline .timeline-date-mobile {
+    display: none;
+  }
+}
+
+/* Fade-in sections */
+.fade-section {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.fade-section.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Modern Header Section */
@@ -267,7 +424,7 @@ body{
 
 .scroll-indicator {
   position: absolute;
-  bottom: -120px;
+  bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
   text-align: center;
@@ -680,7 +837,8 @@ body{
   }
 
   .about-section .content-container {
-    margin: 0 20px;
+    margin: 0 auto;
+    width: 95%;
     padding: 35px 25px;
   }
   
@@ -702,6 +860,16 @@ body{
     padding: 25px 20px;
     margin-bottom: 25px;
   }
+
+  .about-left,
+  .about-right {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  .about-intro p {
+    text-align: center;
+  }
   
   .stats-grid {
     grid-template-columns: repeat(2, 1fr);
@@ -709,13 +877,14 @@ body{
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .about-section {
     padding: 50px 0;
   }
   
   .about-section .content-container {
-    margin: 0 15px;
+    margin: 0 auto;
+    width: 95%;
     padding: 30px 20px;
   }
   
@@ -746,10 +915,10 @@ body{
   .about-section h2 {
     font-size: 1.8rem;
   }
-  
+
   .about-section p {
     font-size: 1rem;
-    text-align: left;
+    text-align: center;
   }
   
   .about-card::before {
@@ -768,47 +937,57 @@ body{
 }
 
 .education-section .timeline-edu {
-  position: relative;
   margin-top: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
 }
 
-.education-section .timeline-edu:before {
+.education-section .edu-entry {
+  display: flex;
+  align-items: flex-start;
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+  padding: 10px 0;
+}
+
+.education-section .edu-year {
+  width: 120px;
+  font-weight: 700;
+  color: #333;
+  text-align: right;
+  margin-right: 20px;
+  position: relative;
+}
+
+.education-section .edu-year::after {
   content: '';
   position: absolute;
+  right: -10px;
   top: 0;
   bottom: 0;
-  left: 34%;
-  transform: translateX(-50%); /* Center the timeline line */
   width: 2px;
   background-color: #666;
 }
 
-.education-section .timeline-item {
-  position: relative;
-  padding-left: 10px;
-  margin-bottom: 40px;
+.education-section .edu-details {
+  padding-left: 20px;
+  text-align: left;
 }
 
-.education-section .timeline-item h3 {
+.education-section .edu-details h3 {
   font-size: 22px;
-  color: #333;
   margin-bottom: 5px;
+  color: #333;
 }
 
-.education-section .timeline-item p {
+.education-section .edu-details p {
   font-size: 16px;
   color: #666;
-  margin-top: 5px;
-}
-
-.education-section .timeline-item .timeline-date {
-  position: absolute;
-  top: 0;
-  left: 330px;
-  font-size: 14px;
-  color: #999;
-  width: 120px;
-  text-align: right;
+  margin: 0;
 }
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
@@ -851,7 +1030,29 @@ body {
   font: normal 16px/1.5 "Inter", sans-serif;
   background: var(--columbia-blue);
   color: var(--black);
-  margin-bottom: 50px;
+  margin: 0 0 50px 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+/* Center section content and limit width */
+.section-container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 900px;
+  width: 100%;
+  padding: 0 1rem;
+}
+
+@media (max-width: 768px) {
+  .section-container {
+    max-width: 100%;
+    width: 100%;
+  }
+}
+
+.timeline-description {
+  text-align: center;
 }
 
 .timeline job {
@@ -1136,7 +1337,7 @@ body {
   background: #120136;
   box-sizing: border-box;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
-  color: #fff;
+  color: #4cc9f0;
   margin-top: 200px;
 }
 
@@ -1149,7 +1350,7 @@ body {
 .skills_chart h1 {
   margin: 0;
   padding: 0;
-  color: #fff;
+  color: #4cc9f0;
   text-align: center;
   letter-spacing: 2px;
   text-transform: uppercase;
@@ -1160,7 +1361,7 @@ body {
   letter-spacing: 1px;
   margin: 0 0 15px;
   text-transform: uppercase;
-  color: #fff;
+  color: #4cc9f0;
   font-weight: bold;
 }
 
@@ -1503,6 +1704,21 @@ body {
   }
   50% {
     opacity: 0.3;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    transform: translateY(-50%) scale(1);
+    box-shadow: 0 0 6px rgba(76, 201, 240, 0.7);
+  }
+  50% {
+    transform: translateY(-50%) scale(1.3);
+    box-shadow: 0 0 10px rgba(76, 201, 240, 0.9);
+  }
+  100% {
+    transform: translateY(-50%) scale(1);
+    box-shadow: 0 0 6px rgba(76, 201, 240, 0.7);
   }
 }
 
@@ -2303,22 +2519,27 @@ margin-top: 20px;
   .skills-main-section {
     padding: 60px 0;
   }
-  
+
   .skills-container {
     padding: 0 15px;
   }
-  
+
   .soft-skills-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .skills-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Modal should take most of the screen width on mobile */
+  .modal {
+    max-width: 95%;
   }
 }
 
 /* Additional mobile layout improvements */
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .about-card {
     padding: 20px;
     margin-bottom: 20px;
@@ -2333,6 +2554,10 @@ margin-top: 20px;
 
   .timeline {
     grid-template-columns: 1fr;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .timeline::before,
@@ -2347,11 +2572,12 @@ margin-top: 20px;
 
   .timeline ol li {
     display: block;
-    width: auto;
+    width: 100%;
     height: auto;
     margin: 30px 0;
     position: relative;
-    padding-left: 20px;
+    padding: 1rem 0;
+    text-align: center;
   }
 
   .timeline ol li:not(:last-child)::after {
@@ -2361,7 +2587,8 @@ margin-top: 20px;
   .timeline ol li::before {
     content: "";
     position: absolute;
-    left: 0;
+    left: 50%;
+    transform: translateX(-50%);
     top: 10px;
     width: 8px;
     height: 8px;
@@ -2371,12 +2598,15 @@ margin-top: 20px;
 
   .timeline ol li div {
     position: static;
-    width: auto;
+    width: 90%;
+    margin: 0 auto;
+    text-align: center;
+    box-sizing: border-box;
     border-radius: 8px;
-    padding: 15px 15px 15px 20px;
+    padding: 1rem;
     background: #fff;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    border-left: 3px solid var(--midnight-green);
+    border-left: none;
   }
 
   .education-section .timeline-edu:before {
@@ -2391,5 +2621,27 @@ margin-top: 20px;
     position: static;
     text-align: left;
     margin-bottom: 5px;
+}
+
+/* Ensure containers span full width on small screens */
+  .content-container,
+  .projects-container,
+  .skills-container {
+    width: 100%;
+    margin: 0 auto;
+    text-align: center;
   }
 }
+
+/* Vertical timeline styles */
+#experience-title,
+.experience-title {
+  font-size: 3rem;
+  text-align: center;
+  color: #2c3e50;
+  margin-bottom: 30px;
+  font-weight: 700;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+

--- a/Resume.js
+++ b/Resume.js
@@ -19,7 +19,6 @@ window.addEventListener('scroll', function() {
   }
 });
 
-const timeline = document.querySelector('.timeline');
 const modalOverlay = document.querySelector('.modal-overlay');
 const modal = document.querySelector('.modal');
 const modalContent = document.querySelector('.modal-content');
@@ -83,7 +82,7 @@ function hideModal() {
 }
 
 // Get all the "Read More" buttons from both timeline sections
-const experienceTimeline = document.querySelector('.experience-section .timeline');
+const experienceTimeline = document.querySelector('#timeline');
 const projectsTimeline = document.querySelector('.projects-section .timeline');
 
 // Function to add event listeners to read more buttons in a timeline
@@ -124,7 +123,7 @@ function addProjectDetailListeners() {
 
 // Function to add event listeners to read more buttons in work experience timeline
 function addWorkExperienceListeners() {
-  const experienceTimeline = document.querySelector('.experience-section .timeline');
+  const experienceTimeline = document.querySelector('#timeline');
   if (experienceTimeline) {
     const readMoreButtons = experienceTimeline.querySelectorAll('button.read-more-btn');
     
@@ -225,6 +224,85 @@ function addSkillCardAnimations() {
 // Initialize animations when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
   addSkillCardAnimations();
+
+  // Fade in sections when they enter the viewport
+  const fadeSections = document.querySelectorAll('.fade-section');
+  const fadeObserver = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    });
+  }, { threshold: 0.2 });
+
+  fadeSections.forEach(section => {
+    fadeObserver.observe(section);
+  });
+});
+
+// Simple timeline navigation without external plugins
+document.addEventListener('DOMContentLoaded', function() {
+  const timeline = document.getElementById('experience-timeline');
+  const items = timeline.querySelectorAll('.timeline-item');
+  const indicator = timeline.querySelector('.timeline-indicator');
+  let currentIndex = 0;
+
+  items.forEach((item, idx) => {
+    const dot = document.createElement('span');
+    dot.className = 'indicator-dot';
+    dot.dataset.date = item.dataset.date;
+    dot.addEventListener('click', () => scrollToIndex(idx));
+    indicator.appendChild(dot);
+  });
+
+  function updateDots() {
+    indicator.querySelectorAll('.indicator-dot').forEach((d, i) => {
+      d.classList.toggle('active', i === currentIndex);
+    });
+  }
+
+  function scrollToIndex(index) {
+    if (index < 0 || index >= items.length) return;
+    currentIndex = index;
+    items[index].scrollIntoView({ behavior: 'smooth', block: 'start' });
+    updateDots();
+  }
+
+
+  let touchStartY = null;
+  timeline.addEventListener('wheel', e => {
+    if (e.deltaY > 0) scrollToIndex(currentIndex + 1);
+    else scrollToIndex(currentIndex - 1);
+  }, { passive: true });
+
+  timeline.addEventListener('touchstart', e => {
+    touchStartY = e.touches[0].clientY;
+  }, { passive: true });
+  timeline.addEventListener('touchend', e => {
+    if (touchStartY === null) return;
+    const delta = e.changedTouches[0].clientY - touchStartY;
+    if (delta < -30) scrollToIndex(currentIndex + 1);
+    else if (delta > 30) scrollToIndex(currentIndex - 1);
+    touchStartY = null;
+  }, { passive: true });
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        currentIndex = Array.from(items).indexOf(entry.target);
+        entry.target.classList.add('visible');
+        updateDots();
+      }
+    });
+  }, { threshold: 0.6 });
+
+  items.forEach(item => observer.observe(item));
+
+  // initial state
+  if (items.length > 0) {
+    items[0].classList.add('visible');
+    updateDots();
+  }
 });
 
 

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
   </div>
 
   <!-- About Me Section -->
-  <section class="about-section" id="about">
+  <section class="about-section fade-section" id="about">
     <div class="content-container">
       <h2>About Me</h2>
       <div class="about-flex">
@@ -124,19 +124,23 @@
   </section>
   
   <!-- Education Section -->
-  <div class="education-section" id="education">
+  <div class="education-section fade-section" id="education">
     <div class="content-container">
       <h2>Education</h2>
       <div class="timeline-edu">
-        <div class="timeline-item">
-          <h3>Memorial University of Newfoundland</h3>
-          <p>Bachelor of Science in Computer Science - 2021-present</p>
-          <span class="timeline-date">2021 - Present</span>
+        <div class="edu-entry">
+          <div class="edu-year">2021 - Present</div>
+          <div class="edu-details">
+            <h3>🏫 Memorial University of Newfoundland</h3>
+            <p>🎓 Bachelor of Science in Computer Science</p>
+          </div>
         </div>
-        <div class="timeline-item">
-          <h3>Canadian International School of Egypt</h3>
-          <p>Ontario Diploma - Graduated in 2021</p>
-          <span class="timeline-date">Graduated in 2021</span>
+        <div class="edu-entry">
+          <div class="edu-year">Graduated in 2021</div>
+          <div class="edu-details">
+            <h3>🏫 Canadian International School of Egypt</h3>
+            <p>🎓 Ontario Diploma</p>
+          </div>
         </div>
         <!-- Add more education entries as needed -->
       </div>
@@ -144,76 +148,68 @@
   </div>
 
 
-  <section class="experience-section">
-    <section class="timeline">
-      <div class="info">
-        <h2>Work Experiences</h2>
-        <p>Here is the history of my past Work experiences</p>
-      </div>
-
-      <ol>
-        <li>
-          <div>
-            <time>January 2023 - Present</time> <job-loc>Storelx, NL, Canada</job-loc>
-            <job>Lead Developer</job>
-            <p class="job-description" id="job1">
-              ● Led the development of a P2P storage marketplace platform using Node.js and React, serving 100+ active
-              users.
-              <br>● Designed and implemented a scalable microservices architecture using Express.js, reducing API
-              response time by 40%
-              <br>● Designed and optimized MongoDB schemas, resulting in 30% faster query performance
-              <br>● Led a team of 3 developers using Agile methodology, achieving 95% on-time sprint completion rate
+  <section class="experience-section section-container fade-section" id="experience">
+    <h2 class="experience-title">Professional Experience</h2>
+    <div id="experience-timeline" class="vertical-timeline">
+      <ul class="timeline-list">
+        <li class="timeline-item" data-date="Jan 2023 - Present">
+          <div class="timeline-date-mobile">Jan 2023 - Present</div>
+          <div class="timeline-card">
+            <h3>Lead Developer</h3>
+            <div class="job-meta">Storelx, NL, Canada</div>
+            <p>
+              ● Led the development of a P2P storage marketplace platform using Node.js and React, serving 100+ active users.<br>
+              ● Designed and implemented a scalable microservices architecture using Express.js, reducing API response time by 40%<br>
+              ● Designed and optimized MongoDB schemas, resulting in 30% faster query performance<br>
+              ● Led a team of 3 developers using Agile methodology, achieving 95% on-time sprint completion rate
             </p>
-            <button class="read-more-btn" data-job-id="job1">Read More</button>
           </div>
         </li>
-        <li>
-          <div>
-            <time>April 2023 - August 2023</time> <job-loc>Union Group FZCO, Dubai, UAE</job-loc>
-            <job>Data Science Intern</job>
-            <p class="job-description" id="job2">
-              ● Developed pipelines using Python and Pandas, processing 20k+ daily transactions with 99.9% accuracy
-              <br>● Created predictive models using scikit-learn, achieving 85% accuracy in sales forecasting
-              <br>● Built interactive dashboards using Plotly and Dash, reducing report generation time by 75%
+        <li class="timeline-item" data-date="Apr 2023 - Aug 2023">
+          <div class="timeline-date-mobile">Apr 2023 - Aug 2023</div>
+          <div class="timeline-card">
+            <h3>Data Science Intern</h3>
+            <div class="job-meta">Union Group FZCO, Dubai, UAE</div>
+            <p>
+              ● Developed pipelines using Python and Pandas, processing 20k+ daily transactions with 99.9% accuracy<br>
+              ● Created predictive models using scikit-learn, achieving 85% accuracy in sales forecasting<br>
+              ● Built interactive dashboards using Plotly and Dash, reducing report generation time by 75%
             </p>
-            <button class="read-more-btn" data-job-id="job2">Read More</button>
           </div>
         </li>
-        <li>
-          <div>
-            <time>July 2022 - October 2022</time> <job-loc>Hoopoe Digital, Cairo, Egypt</job-loc>
-            <job>Full Stack Intern</job>
-            <p class="job-description" id="job3">
-              ● Developed a customer tracking application serving 5+ shopping malls and processing 20K+ daily visitors
-              <br>● Built RESTful APIs using Node.js and Express, handling 1000+ requests per minute with 99.9% uptime
-              <br>● Implemented real-time analytics dashboard using React and D3.js, processing 10k+ daily data points
-              <br>● Contributed to microservices architecture design, improving system scalability by 40%
+        <li class="timeline-item" data-date="Jul 2022 - Oct 2022">
+          <div class="timeline-date-mobile">Jul 2022 - Oct 2022</div>
+          <div class="timeline-card">
+            <h3>Full Stack Intern</h3>
+            <div class="job-meta">Hoopoe Digital, Cairo, Egypt</div>
+            <p>
+              ● Developed a customer tracking application serving 5+ shopping malls and processing 20K+ daily visitors<br>
+              ● Built RESTful APIs using Node.js and Express, handling 1000+ requests per minute with 99.9% uptime<br>
+              ● Implemented real-time analytics dashboard using React and D3.js, processing 10k+ daily data points<br>
+              ● Contributed to microservices architecture design, improving system scalability by 40%
             </p>
-            <button class="read-more-btn" data-job-id="job3">Read More</button>
           </div>
         </li>
-        <li>
-          <div>
-            <time>April 2022 - July 2022</time> <job-loc>Union Group, Cairo, Egypt</job-loc>
-            <job>Data Science Intern</job>
-            <p class="job-description" id="job4">
-              ● Analyzed 5+ years of financial data using Python and SQL, identifying patterns that led to 15% cost
-              reduction
-              <br>● Created automated data cleaning pipelines processing 10k+ records daily with 99% accuracy
-              <br>● Developed interactive Power BI dashboards viewed by 50+ stakeholders daily
-              <br>● Implemented statistical analysis methods resulting in 25% more accurate financial forecasting
-              <br>● Documented 20+ technical processes, reducing onboarding time for new team members by 50%
+        <li class="timeline-item" data-date="Apr 2022 - Jul 2022">
+          <div class="timeline-date-mobile">Apr 2022 - Jul 2022</div>
+          <div class="timeline-card">
+            <h3>Data Science Intern</h3>
+            <div class="job-meta">Union Group, Cairo, Egypt</div>
+            <p>
+              ● Analyzed 5+ years of financial data using Python and SQL, identifying patterns that led to 15% cost reduction<br>
+              ● Created automated data cleaning pipelines processing 10k+ records daily with 99% accuracy<br>
+              ● Developed interactive Power BI dashboards viewed by 50+ stakeholders daily<br>
+              ● Implemented statistical analysis methods resulting in 25% more accurate financial forecasting<br>
+              ● Documented 20+ technical processes, reducing onboarding time for new team members by 50%
             </p>
-            <button class="read-more-btn" data-job-id="job4">Read More</button>
           </div>
         </li>
-        <li></li>
-      </ol>
-
-    </section>
+      </ul>
+      <div class="timeline-indicator"></div>
+    </div>
   </section>
 
-  <section class="projects-section">
+  <section class="projects-section fade-section">
     <div class="projects-container">
       <div class="projects-header">
         <h2>My Projects</h2>
@@ -291,7 +287,7 @@
   </div>
 
   <!-- Skills section moved after projects -->
-  <section class="skills-main-section">
+  <section class="skills-main-section fade-section">
     <div class="skills-container">
       <div class="skills-header">
         <h2>Skills & Expertise</h2>
@@ -528,7 +524,7 @@
   </section>
 
   
-  <div class="profile-container">
+  <div class="profile-container fade-section">
     <div class="modern-contact-section" id="card">
       <div class="contact-background">
         <div class="geometric-patterns">


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow
- create centered section container styles
- modernize the vertical timeline with scroll snapping
- tweak timeline dot styling and make dates show on hover
- ensure the first experience entry is active on page load
- refactor timeline into a scrollable carousel with indicator dots
- remove arrows and left line from timeline
- adjust dot tooltip direction and mobile centering

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf5d1f7c8332b3406a132a629de4