### PR TITLE
feat: add token-based light and dark themes

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -1,5 +1,181 @@
+/* Theme tokens */
 :root {
-  --accent-color: #00bcd4;
+  --bg-base:#0F1115;
+  --bg-elevated:#12161F;
+  --bg-overlay:rgba(0,0,0,0.35);
+
+  --text-primary:#E9EDF3;
+  --text-secondary:#C7CFDB;
+  --text-muted:#9AA3B2;
+  --text-onAccent:#FFFFFF;
+
+  --border-hairline:#2A2F3A;
+  --border-strong:#3A414F;
+
+  --accent-solid:#2F6EEA;
+  --accent-soft:rgba(47,110,234,0.12);
+  --accent-hover:#3A79F3;
+
+  --chip-bg:rgba(255,255,255,0.06);
+  --chip-border:transparent;
+  --chip-text:#E9EDF3;
+
+  --code-bg:#0C0F14;
+  --code-inline-bg:rgba(255,255,255,0.06);
+  --focus-ring:#2F6EEA;
+
+  --shadow-1:0 4px 12px rgba(0,0,0,0.20);
+}
+
+:root[data-theme='light']{
+  --bg-base:#F7F9FC;
+  --bg-elevated:#FFFFFF;
+  --bg-overlay:rgba(0,0,0,0.06);
+
+  --text-primary:#0E1116;
+  --text-secondary:#2B2F36;
+  --text-muted:#5D6676;
+  --text-onAccent:#FFFFFF;
+
+  --border-hairline:#E4E8EF;
+  --border-strong:#CBD2D9;
+
+  --accent-solid:#2F6EEA;
+  --accent-soft:rgba(47,110,234,0.10);
+  --accent-hover:#255FDB;
+
+  --chip-bg:#F0F3FA;
+  --chip-border:#E4E8EF;
+  --chip-text:#0E1116;
+
+  --code-bg:#F4F6FB;
+  --code-inline-bg:#EEF2F9;
+  --focus-ring:#2F6EEA;
+
+  --shadow-1:0 8px 24px rgba(0,0,0,0.10);
+}
+
+/* Legacy variable aliases for unmigrated components */
+:root {
+  --color-charcoal: var(--bg-base);
+  --color-slate: var(--bg-elevated);
+  --color-offwhite: var(--text-primary);
+  --color-midgray: var(--text-secondary);
+  --color-border: var(--border-hairline);
+  --accent-color: var(--accent-solid);
+}
+
+:root[data-theme='light'] {
+  --color-charcoal: var(--bg-base);
+  --color-slate: var(--bg-elevated);
+  --color-offwhite: var(--text-primary);
+  --color-midgray: var(--text-secondary);
+  --color-border: var(--border-hairline);
+  --accent-color: var(--accent-solid);
+}
+
+body {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: 'Inter', sans-serif;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Initial hero code intro */
+.code-intro {
+  position: fixed;
+  inset: 0;
+  background: var(--code-bg);
+  color: var(--accent-solid);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Fira Code', monospace;
+  font-size: 1rem;
+  z-index: 999;
+  opacity: 1;
+  transition: opacity 2.5s ease-in-out;
+}
+.code-intro.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+code, .code-inline {
+  background: var(--code-inline-bg);
+  color: var(--text-primary);
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+  font-family: 'Fira Code', monospace;
+}
+
+pre code {
+  background: var(--code-bg);
+  display: block;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+/* Navigation bar */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: 2rem;
+  padding: 1rem 2rem;
+  z-index: 900;
+  transition: background 0.3s ease, opacity 0.6s ease;
+  opacity: 1;
+}
+.navbar.scrolled {
+  background: var(--bg-overlay);
+  backdrop-filter: blur(4px);
+}
+.nav-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-family: 'Poppins', sans-serif;
+  position: relative;
+}
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--accent-solid);
+  transition: width 0.3s ease;
+}
+.nav-link:hover::after,
+.nav-link.active::after {
+  width: 100%;
+}
+
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+#theme-toggle:hover {
+  background: var(--accent-soft);
+}
+
+/* Hero section wrapper */
+#hero {
+  position: relative;
 }
 
 /* Professional Experience Timeline */
@@ -66,7 +242,7 @@
   top: 0;
   width: 2px;
   height: 100%;
-  background: linear-gradient(to bottom, rgba(0, 188, 212, 0.4), rgba(99, 102, 241, 0.4));
+  background: linear-gradient(to bottom, rgba(37, 99, 235, 0.4), rgba(37, 99, 235, 0));
   z-index: -1;
   left: 4px;
 }
@@ -141,14 +317,14 @@
 /* Date styling inside cards */
 .timeline-card-date {
   display: inline-block;
-  background: rgba(0, 188, 212, 0.1);
-  color: #0ea5e9;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--accent-color);
   padding: 4px 12px;
   border-radius: 15px;
   font-size: 0.8rem;
   font-weight: 600;
   margin-bottom: 12px;
-  border: 1px solid rgba(0, 188, 212, 0.2);
+  border: 1px solid rgba(37, 99, 235, 0.2);
 }
 
 .timeline-card-company {
@@ -268,7 +444,7 @@
   display: block;
   width: 60px;
   height: 4px;
-  background-color: #0ea5e9;      /* Accent line */
+  background-color: var(--accent-color);
   border-radius: 2px;
   margin: 0.5rem auto 0 auto;     /* Centered underline */
 }
@@ -292,26 +468,25 @@
 }
 
 /* Modern Header Section */
-.welcome-section {
+#hero {
   position: relative;
   height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(to bottom, var(--bg-base), var(--bg-elevated));
   overflow: hidden;
   min-height: 100vh;     /* Ensures section fills the whole screen */
-  display: flex;
   flex-direction: column;
 }
 
-.background-animation {
+#heroBG {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0.3;
+  opacity: 0.15;
   z-index: 1;
 }
 
@@ -323,9 +498,13 @@
 
 .shape {
   position: absolute;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 50%;
-  animation: float 6s ease-in-out infinite;
+  animation: float 10s ease-in-out infinite;
+  filter: blur(40px);
+  --px: 0px;
+  --py: 0px;
+  transform: translate(var(--px), var(--py));
 }
 
 .shape-1 {
@@ -381,9 +560,18 @@
   position: relative;
   z-index: 2;
   text-align: center;
-  color: white;
+  color: var(--text-primary);
   max-width: 800px;
   padding: 0 20px;
+}
+
+.glass-panel {
+  background: var(--bg-elevated);
+  border-radius: 16px;
+  padding: 40px 30px;
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border-hairline);
+  box-shadow: var(--shadow-1);
 }
 
 .main-title {
@@ -395,76 +583,51 @@
   font-size: 1.5rem;
   font-weight: 300;
   margin-bottom: 10px;
-  opacity: 0.9;
+  color: var(--text-secondary);
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  font-family: 'Inter', sans-serif;
+  margin-bottom: 20px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.company-tag {
+  margin-bottom: 25px;
+}
+
+.company-tag a {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  color: var(--chip-text);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.company-tag a:hover {
+  background: var(--accent-soft);
+  color: var(--accent-solid);
 }
 
 .name {
   display: block;
   font-size: 4rem;
   font-weight: 700;
-  background: linear-gradient(45deg, #ffffff, #f0f8ff, #e6f3ff);
+  background: linear-gradient(45deg, var(--text-primary), var(--text-secondary));
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  animation: nameGlow 3s ease-in-out infinite alternate;
+  color: transparent;
 }
 
-@keyframes nameGlow {
-  0% {
-    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  }
-  100% {
-    text-shadow: 0 0 20px rgba(255,255,255,0.5);
-  }
-}
 
-.title-section {
-  margin-bottom: 30px;
-}
 
-.primary-title {
-  font-size: 1.8rem;
-  font-weight: 600;
-  margin-bottom: 15px;
-  color: #f0f8ff;
-}
 
-.company-info {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  flex-wrap: wrap;
-}
 
-.company-name {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.company-link {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 25px;
-  text-decoration: none;
-  color: white;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-.company-link:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-}
-
-.role-tags {
+.skill-tags {
   display: flex;
   justify-content: center;
   gap: 15px;
@@ -472,28 +635,21 @@
   flex-wrap: wrap;
 }
 
-.role-tag {
-  padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: 20px;
-  font-size: 0.9rem;
+.skill-tag {
+  padding: 6px 12px;
+  background: var(--chip-bg);
+  border-radius: 9999px;
+  font-size: 0.85rem;
   font-weight: 500;
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  animation: tagFloat 4s ease-in-out infinite;
+  border: 1px solid var(--chip-border);
+  color: var(--chip-text);
+  transition: background 0.2s ease, text-decoration 0.2s ease;
 }
 
-.role-tag:nth-child(1) { animation-delay: 0s; }
-.role-tag:nth-child(2) { animation-delay: 1s; }
-.role-tag:nth-child(3) { animation-delay: 2s; }
-
-@keyframes tagFloat {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-5px);
-  }
+.skill-tag:hover {
+  background: var(--accent-soft);
+  text-decoration: underline;
+  text-underline-offset: 4px;
 }
 
 .header-actions {
@@ -505,56 +661,42 @@
 }
 
 .cta-button {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 10px;
-  padding: 15px 30px;
-  border-radius: 30px;
+  padding: 12px 28px;
+  border-radius: 8px;
   text-decoration: none;
   font-weight: 600;
   font-size: 1rem;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  box-shadow: var(--shadow-1);
+  color: var(--text-primary);
 }
 
-.cta-button::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-  transition: left 0.5s;
-}
-
-.cta-button:hover::before {
-  left: 100%;
+.cta-button:hover {
+  transform: scale(1.02);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
 }
 
 .cta-button.primary {
-  background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-  color: white;
-  box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
+  border: none;
 }
 
 .cta-button.primary:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 25px rgba(255, 107, 107, 0.6);
+  background: var(--accent-hover);
 }
 
 .cta-button.secondary {
   background: transparent;
-  color: white;
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(10px);
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
 }
 
 .cta-button.secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.8);
-  transform: translateY(-3px);
+  background: var(--accent-soft);
 }
 
 .scroll-indicator {
@@ -565,23 +707,24 @@
 }
 
 .down-arrow {
-  border: solid rgba(255, 255, 255, 0.7);
-  border-width: 0 2px 2px 0;
+  width: 12px;
+  height: 12px;
+  border-width: 0 3px 3px 0;
+  border-style: solid;
+  border-color: var(--accent-solid);
   display: inline-block;
-  padding: 8px;
+  padding: 10px;
   transform: rotate(45deg);
-  animation: arrowBounce 2s infinite;
+  animation: arrowBounce 2.5s infinite ease-in-out;
+  opacity: 0;
 }
 
 @keyframes arrowBounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%, 100% {
     transform: rotate(45deg) translateY(0);
   }
-  40% {
-    transform: rotate(45deg) translateY(-10px);
-  }
-  60% {
-    transform: rotate(45deg) translateY(-5px);
+  50% {
+    transform: rotate(45deg) translateY(1px);
   }
 }
 
@@ -607,69 +750,24 @@
   }
 }
 
-/* Remove old welcome section styles */
-.welcome-section a{
-  font-weight: 500;
-  text-decoration: underline;
-  
-  font-size: 16px;
-  position: relative;
-  color: #333;
-}
-
-.storelx-web{
-  font-weight: 100;
-  text-decoration: underline;
-  font-size: 10px;
-  position: relative;
-  color: #b9b1b1;
-}
-
-.ceo-text {
-  font-size: 15px;
-  color: #666;
-  position: relative;
-  top: 0px;
-}
-
 /* Styling for the "About Me" section */
 .about-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
   padding: 80px 0;
-  position: relative;
-  overflow: hidden;
 }
 
 .about-section .content-container {
   max-width: 1000px;
   margin: 0 auto;
   padding: 2rem 1rem;
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 25px;
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  position: relative;
-  z-index: 1;
-  transition: all 0.3s ease;
-  text-align: center;
-}
-
-.about-section .content-container:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 35px 70px rgba(0, 0, 0, 0.2);
 }
 
 .about-section h2 {
   font-size: 3rem;
-  color: #2c3e50;
   margin-bottom: 40px;
   text-align: center;
   font-weight: 700;
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  
 }
 
 .about-section h2::after {
@@ -677,7 +775,7 @@
   display: block;
   width: 80px;
   height: 4px;
-  background: linear-gradient(45deg, #667eea, #764ba2);
+  background: var(--accent-solid);
   margin: 15px auto 0;
   border-radius: 2px;
   animation: underlineGrow 1s ease-out;
@@ -728,7 +826,7 @@
 
 .highlight-item {
   background: rgba(102, 126, 234, 0.05);
-  border-left: 4px solid #764ba2;
+  border-left: 4px solid var(--accent-color);
   padding: 12px 16px;
   border-radius: 10px;
   font-size: 0.95rem;
@@ -749,7 +847,7 @@
   border-radius: 15px;
   padding: 30px;
   margin-bottom: 30px;
-  border-left: 4px solid #667eea;
+  border-left: 4px solid var(--accent-color);
   position: relative;
   transition: all 0.3s ease;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
@@ -773,7 +871,7 @@
 
 .about-card:hover {
   background: rgba(102, 126, 234, 0.1);
-  border-left-color: #764ba2;
+  border-left-color: var(--accent-color);
   transform: translateX(5px);
   box-shadow: 0 15px 40px rgba(102, 126, 234, 0.2);
 }
@@ -828,10 +926,7 @@
 .stat-number {
   font-size: 2.5rem;
   font-weight: 700;
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent-color);
   margin-bottom: 8px;
   animation: countUp 1.5s ease-out;
 }
@@ -872,7 +967,7 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #667eea, #764ba2, #f093fb);
+  background: var(--accent-color);
   border-radius: 15px 15px 0 0;
   transform: scaleX(0);
   transition: transform 0.3s ease;
@@ -1015,18 +1110,7 @@
   margin: 0;
 }
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
-
-:root {
-  --white: #fff;
-  --black: #323135;
-  --crystal: #a8dadd;
-  --columbia-blue: #cee9e4;
-  --midnight-green: #01565b;
-  --yellow: #e5f33d;
-  --timeline-gradient: rgba(206, 233, 228, 1) 0%, rgba(206, 233, 228, 1) 50%,
-    rgba(206, 233, 228, 0) 100%;
-}
+/* removed duplicate root and font import */
 
 *,
 *::before,
@@ -1054,11 +1138,19 @@ img {
 
 body {
   font: normal 16px/1.5 "Inter", sans-serif;
-  background: var(--columbia-blue);
-  color: var(--black);
+  background: var(--color-offwhite);
+  color: var(--color-charcoal);
   margin: 0 0 50px 0;
   padding: 0;
   overflow-x: hidden;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Poppins", sans-serif;
+}
+
+code, pre {
+  font-family: "Fira Code", monospace;
 }
 
 /* Center section content and limit width */
@@ -1190,7 +1282,7 @@ body {
 .profile-container {
   width: 100%;
   min-height: 100vh;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--color-slate);
   padding: 80px 0;
   position: relative;
   overflow: hidden;
@@ -1366,7 +1458,7 @@ body {
   left: 0;
   right: 0;
   height: 5px;
-  background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #ffeaa7);
+  background: var(--accent-color);
   border-radius: 25px 25px 0 0;
 }
 
@@ -1386,7 +1478,7 @@ body {
   position: relative;
   width: 80px;
   height: 80px;
-  background: linear-gradient(135deg, #667eea, #764ba2);
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color));
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -1488,10 +1580,7 @@ body {
 .last-name {
   display: block;
   font-weight: 700;
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent-color);
 }
 
 .contact-role {
@@ -1548,7 +1637,7 @@ body {
 }
 
 .detail-value:hover {
-  color: #667eea;
+  color: var(--accent-color);
 }
 
 .social-links {
@@ -1623,24 +1712,29 @@ body {
 }
 
 .contact-btn.primary {
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  color: white;
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+  background: var(--accent-color);
+  color: var(--color-offwhite);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 
 .contact-btn.primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.6);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.25);
 }
 
 .contact-btn.secondary {
   background: transparent;
-  color: #667eea;
-  border: 2px solid #667eea;
+  color: var(--accent-color);
+  border: 2px solid var(--accent-color);
 }
 
 .contact-btn.secondary:hover {
-  background: #667eea;
+  background: var(--accent-color);
+  color: var(--color-offwhite);
+}
+
+.contact-btn.secondary:hover {
+  background: var(--accent-color);
   color: white;
   transform: translateY(-2px);
 }
@@ -1723,7 +1817,7 @@ body {
   cursor: default;
   margin: 20px;
   margin-left:70px;
-  color:var(--columbia-blue);
+  color:var(--accent-color);
 }
 
 .back {
@@ -1777,7 +1871,7 @@ margin-top: 20px;
 }
 
 .projects-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--color-offwhite);
   padding: 80px 0;
   margin: 60px 0;
   position: relative;
@@ -1848,7 +1942,7 @@ margin-top: 20px;
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4);
+  background: var(--accent-color);
   border-radius: 20px 20px 0 0;
 }
 
@@ -1872,7 +1966,7 @@ margin-top: 20px;
 }
 
 .project-date {
-  background: linear-gradient(135deg, #667eea, #764ba2);
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color));
   color: white;
   padding: 5px 15px;
   border-radius: 20px;
@@ -1917,13 +2011,12 @@ margin-top: 20px;
 }
 
 .tech-tag {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-  color: white;
+  background: var(--accent-color);
+  color: var(--color-offwhite);
   padding: 5px 12px;
   border-radius: 15px;
   font-size: 0.8rem;
   font-weight: 500;
-  box-shadow: 0 2px 10px rgba(240, 147, 251, 0.3);
 }
 
 .project-actions {
@@ -1933,8 +2026,8 @@ margin-top: 20px;
 }
 
 .project-link {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  background: var(--accent-color);
+  color: var(--color-offwhite);
   padding: 12px 20px;
   border-radius: 25px;
   text-decoration: none;
@@ -1942,13 +2035,11 @@ margin-top: 20px;
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.3s ease;
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+  transition: transform 0.3s ease;
 }
 
 .project-link:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.6);
 }
 
 /* Responsive Design for Projects */
@@ -1979,7 +2070,7 @@ margin-top: 20px;
 
 /* Modern Skills Section */
 .skills-main-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--color-offwhite);
   padding: 80px 0;
   position: relative;
   overflow: hidden;
@@ -2014,11 +2105,9 @@ margin-top: 20px;
   font-size: 3.5rem;
   font-weight: 700;
   margin-bottom: 15px;
-  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  background: linear-gradient(45deg, #ffffff, #f0f8ff);
+  background: linear-gradient(45deg, #e5e7eb, #9ca3af);
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: transparent;
 }
 
 .skills-header p {
@@ -2093,7 +2182,7 @@ margin-top: 20px;
   transform: translateX(-50%);
   width: 50px;
   height: 3px;
-  background: linear-gradient(45deg, #667eea, #764ba2);
+  background: var(--accent-color);
   border-radius: 2px;
 }
 
@@ -2131,7 +2220,7 @@ margin-top: 20px;
 
 .skill-percentage {
   font-weight: 700;
-  color: #667eea;
+  color: var(--accent-color);
   font-size: 1rem;
 }
 
@@ -2198,7 +2287,7 @@ margin-top: 20px;
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, #667eea, #764ba2, #f093fb, #f5576c);
+  background: var(--accent-color);
   border-radius: 20px 20px 0 0;
 }
 

--- a/Resume.js
+++ b/Resume.js
@@ -1,12 +1,98 @@
-// Add smooth scrolling to navigate to sections
-document.getElementById('scroll-down').addEventListener('click', function() {
-  const target = document.getElementById('about');
-  if (target) {
-    target.scrollIntoView({
-      behavior: 'smooth'
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const savedTheme = localStorage.getItem('theme');
+document.documentElement.setAttribute('data-theme', savedTheme || (prefersDark ? 'dark' : 'light'));
+
+document.addEventListener('DOMContentLoaded', () => {
+  const codeBlock = document.getElementById('code-block');
+  const navbar = document.querySelector('.navbar');
+  const codeText = [
+    '<section id="hero">',
+    '  <h1>Noureldeen Fahmy</h1>',
+    '</section>'
+  ].join('\n');
+  let idx = 0;
+  (function type() {
+    if (idx < codeText.length) {
+      codeBlock.textContent += codeText.charAt(idx);
+      idx++;
+      setTimeout(type, 20);
+    }
+  })();
+
+  runHeroAnimations();
+
+  document.getElementById('scrollCue').addEventListener('click', () => {
+    const target = document.getElementById('about');
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+
+  window.addEventListener('scroll', () => {
+    navbar.classList.toggle('scrolled', window.scrollY > 10);
+  });
+
+  document.querySelectorAll('.nav-link').forEach(link => {
+    link.addEventListener('click', () => {
+      document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
+      link.classList.add('active');
+    });
+  });
+
+  const themeToggle = document.getElementById('theme-toggle');
+  themeToggle.addEventListener('click', () => {
+    const root = document.documentElement;
+    const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+});
+
+const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+function runHeroAnimations() {
+  if (prefersReduced) {
+    gsap.set(["#hero", "[data-hero-el]"], { opacity: 1, y: 0, clearProps: "all" });
+    return;
+  }
+
+  gsap.registerPlugin(ScrollTrigger);
+  const tl = gsap.timeline({ defaults: { ease: "power3.out" } });
+
+  tl.to("#code-intro", { opacity: 1, duration: 0.2 })
+    .to("#code-intro", { opacity: 0, filter: "blur(10px)", pointerEvents: "none", duration: 0.6, delay: 1.3 });
+
+  tl.fromTo("#heroCard", { opacity: 0, y: 16, filter: "blur(8px)" },
+                     { opacity: 1, y: 0, filter: "blur(0px)", duration: 0.8 }, "<0.1");
+
+  tl.from("[data-hero-h1]", { opacity: 0, y: 10, duration: 0.6 }, "-=0.2")
+    .from("[data-hero-sub]", { opacity: 0, y: 10, duration: 0.5 }, "-=0.2")
+    .from("[data-chip]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
+    .from("[data-skill]", { opacity: 0, y: 10, stagger: 0.08, duration: 0.4 }, "-=0.2")
+    .from("[data-cta]", { opacity: 0, y: 8, stagger: 0.08, duration: 0.35 }, "-=0.2")
+    .to("#scrollCue", { opacity: 1, duration: 0.3 }, "-=0.1");
+
+  const card = document.querySelector("#heroCard");
+  if (window.matchMedia("(pointer: fine)").matches && card) {
+    card.addEventListener("mousemove", (e) => {
+      const r = card.getBoundingClientRect();
+      const x = (e.clientX - (r.left + r.width / 2)) / r.width;
+      const y = (e.clientY - (r.top + r.height / 2)) / r.height;
+      gsap.to("#heroBG", { x: x * 8, y: y * 6, duration: 0.3, overwrite: true });
+      gsap.to("[data-hero-h1]", { x: x * 3, y: y * 2, duration: 0.3, overwrite: true });
     });
   }
-});
+
+  const btns = gsap.utils.toArray("[data-cta]");
+  btns.forEach((b) => {
+    b.addEventListener("mouseenter", () =>
+      gsap.to(b, { scale: 1.02, boxShadow: "0 10px 24px rgba(0,0,0,.18)", duration: 0.18, ease: "power2.out" })
+    );
+    b.addEventListener("mouseleave", () =>
+      gsap.to(b, { scale: 1.0, boxShadow: "0 4px 12px rgba(0,0,0,.12)", duration: 0.18, ease: "power2.out" })
+    );
+  });
+}
 
 // Reveal the clean strip for "About Me" section on scroll
 window.addEventListener('scroll', function() {

--- a/index.html
+++ b/index.html
@@ -1,16 +1,26 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Welcome to Nour's Website</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="Resume.css">
 </head>
 
 <body>
-  <div class="welcome-section" id="welcome">
-    <div class="background-animation">
+  <div id="code-intro" class="code-intro"><pre id="code-block"></pre></div>
+  <nav class="navbar">
+    <a href="#hero" class="nav-link active">Home</a>
+    <a href="#about" class="nav-link">About</a>
+    <a href="#card" class="nav-link">Contact</a>
+    <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+  </nav>
+  <div class="welcome-section" id="hero">
+    <div class="background-animation" id="heroBG">
       <div class="floating-shapes">
         <div class="shape shape-1"></div>
         <div class="shape shape-2"></div>
@@ -19,44 +29,37 @@
         <div class="shape shape-5"></div>
       </div>
     </div>
-    
+
     <div class="header-content">
-      <div class="profile-intro">
-        <h1 class="main-title">
+      <div class="profile-intro glass-panel" id="heroCard" role="region" aria-label="Intro">
+        <h1 class="main-title" data-hero-h1>
           <span class="greeting">Hello, I'm</span>
-          <span class="name">Noureldeen Fahmy</span>
+          <span class="name" id="hero-name">Noureldeen Fahmy</span>
         </h1>
-        
-        <div class="title-section">
-          <div class="company-info">
-            <span class="company-name">Storelx</span>
-            <a href="https://www.storelx.com" target="_blank" class="company-link">
-              <span class="link-icon">🌐</span>
-              <span class="link-text">www.storelx.com</span>
-            </a>
-          </div>
+        <p class="hero-tagline" data-hero-sub>Full-stack developer &amp; data scientist</p>
+        <div class="company-tag">
+          <a href="https://www.storelx.com" target="_blank" data-chip>Storelx</a>
         </div>
-        
-        <div class="role-tags">
-          <span class="role-tag">Full-Stack Developer</span>
-          <span class="role-tag">Data Scientist</span>
-          <span class="role-tag">Team Leader</span>
+        <div class="skill-tags">
+          <span class="skill-tag" data-skill>React</span>
+          <span class="skill-tag" data-skill>Node.js</span>
+          <span class="skill-tag" data-skill>Python</span>
+          <span class="skill-tag" data-skill>AWS</span>
         </div>
-        
         <div class="header-actions">
-          <a href="#card" class="cta-button primary">
+          <a href="#card" class="cta-button primary" data-cta>
             <span class="button-icon">📧</span>
             <span class="button-text">Contact Me</span>
           </a>
-          <a href="#about" class="cta-button secondary">
+          <a href="#about" class="cta-button secondary" data-cta>
             <span class="button-icon">👤</span>
             <span class="button-text">About Me</span>
           </a>
         </div>
       </div>
-      
+
       <div class="scroll-indicator">
-        <div class="down-arrow" id="scroll-down"></div>
+        <div class="down-arrow" id="scrollCue"></div>
       </div>
     </div>
   </div>
@@ -618,6 +621,8 @@
   </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
   <script src="Resume.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- introduce semantic color tokens for dark and light modes and map legacy variables
- persist theme preference with localStorage and system defaults
- restyle chips, skill tags, and CTAs to consume new tokens and accent styles

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689e236266bc833289204be621728957