### PR TITLE
feat: add token-based light/dark themes and polished hero

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -1,5 +1,181 @@
+/* Theme tokens */
 :root {
-  --accent-color: #00bcd4;
+  --bg-base:#0F1115;
+  --bg-elevated:#12161F;
+  --bg-overlay:rgba(0,0,0,0.35);
+
+  --text-primary:#E9EDF3;
+  --text-secondary:#C7CFDB;
+  --text-muted:#9AA3B2;
+  --text-onAccent:#FFFFFF;
+
+  --border-hairline:#2A2F3A;
+  --border-strong:#3A414F;
+
+  --accent-solid:#2F6EEA;
+  --accent-soft:rgba(47,110,234,0.12);
+  --accent-hover:#3A79F3;
+
+  --chip-bg:rgba(255,255,255,0.06);
+  --chip-border:transparent;
+  --chip-text:#E9EDF3;
+
+  --code-bg:#0C0F14;
+  --code-inline-bg:rgba(255,255,255,0.06);
+  --focus-ring:#2F6EEA;
+
+  --shadow-1:0 4px 12px rgba(0,0,0,0.20);
+}
+
+:root[data-theme='light']{
+  --bg-base:#F7F9FC;
+  --bg-elevated:#FFFFFF;
+  --bg-overlay:rgba(0,0,0,0.06);
+
+  --text-primary:#0E1116;
+  --text-secondary:#2B2F36;
+  --text-muted:#5D6676;
+  --text-onAccent:#FFFFFF;
+
+  --border-hairline:#E4E8EF;
+  --border-strong:#CBD2D9;
+
+  --accent-solid:#2F6EEA;
+  --accent-soft:rgba(47,110,234,0.10);
+  --accent-hover:#255FDB;
+
+  --chip-bg:#F0F3FA;
+  --chip-border:#E4E8EF;
+  --chip-text:#0E1116;
+
+  --code-bg:#F4F6FB;
+  --code-inline-bg:#EEF2F9;
+  --focus-ring:#2F6EEA;
+
+  --shadow-1:0 8px 24px rgba(0,0,0,0.10);
+}
+
+/* Legacy variable aliases for unmigrated components */
+:root {
+  --color-charcoal: var(--bg-base);
+  --color-slate: var(--bg-elevated);
+  --color-offwhite: var(--text-primary);
+  --color-midgray: var(--text-secondary);
+  --color-border: var(--border-hairline);
+  --accent-color: var(--accent-solid);
+}
+
+:root[data-theme='light'] {
+  --color-charcoal: var(--bg-base);
+  --color-slate: var(--bg-elevated);
+  --color-offwhite: var(--text-primary);
+  --color-midgray: var(--text-secondary);
+  --color-border: var(--border-hairline);
+  --accent-color: var(--accent-solid);
+}
+
+body {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: 'Inter', sans-serif;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Initial hero code intro */
+.code-intro {
+  position: fixed;
+  inset: 0;
+  background: var(--code-bg);
+  color: var(--accent-solid);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Fira Code', monospace;
+  font-size: 1rem;
+  z-index: 999;
+  opacity: 1;
+  transition: opacity 2.5s ease-in-out;
+}
+.code-intro.fade-out {
+  opacity: 0;
+  pointer-events: none;
+}
+
+code, .code-inline {
+  background: var(--code-inline-bg);
+  color: var(--text-primary);
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+  font-family: 'Fira Code', monospace;
+}
+
+pre code {
+  background: var(--code-bg);
+  display: block;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+/* Navigation bar */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  gap: 2rem;
+  padding: 1rem 2rem;
+  z-index: 900;
+  transition: background 0.3s ease, opacity 0.6s ease;
+  opacity: 1;
+}
+.navbar.scrolled {
+  background: var(--bg-overlay);
+  backdrop-filter: blur(4px);
+}
+.nav-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-family: 'Poppins', sans-serif;
+  position: relative;
+}
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--accent-solid);
+  transition: width 0.3s ease;
+}
+.nav-link:hover::after,
+.nav-link.active::after {
+  width: 100%;
+}
+
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+#theme-toggle:hover {
+  background: var(--accent-soft);
+}
+
+/* Hero section wrapper */
+#hero {
+  position: relative;
 }
 
 /* Professional Experience Timeline */
@@ -66,7 +242,7 @@
   top: 0;
   width: 2px;
   height: 100%;
-  background: linear-gradient(to bottom, rgba(0, 188, 212, 0.4), rgba(99, 102, 241, 0.4));
+  background: linear-gradient(to bottom, rgba(37, 99, 235, 0.4), rgba(37, 99, 235, 0));
   z-index: -1;
   left: 4px;
 }
@@ -116,20 +292,20 @@
 /* ensure indicator stays centered */
 
 .vertical-timeline .timeline-card {
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(8px);
+  background: var(--bg-elevated);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   width: calc(100% - 2rem);
   margin: 0 auto;
   border-left: 4px solid transparent;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
 }
 
 .vertical-timeline .timeline-card h3 {
   margin-top: 0;
-  color: #01565b;
+  color: var(--text-primary);
   font-size: 1.25rem;
 }
 
@@ -141,32 +317,32 @@
 /* Date styling inside cards */
 .timeline-card-date {
   display: inline-block;
-  background: rgba(0, 188, 212, 0.1);
-  color: #0ea5e9;
+  background: var(--accent-soft);
+  color: var(--accent-solid);
   padding: 4px 12px;
   border-radius: 15px;
   font-size: 0.8rem;
   font-weight: 600;
   margin-bottom: 12px;
-  border: 1px solid rgba(0, 188, 212, 0.2);
+  border: 1px solid var(--accent-soft);
 }
 
 .timeline-card-company {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   margin-bottom: 8px;
   font-style: italic;
 }
 
 .timeline-card-role {
-  color: #01565b;
+  color: var(--text-primary);
   font-size: 1.1rem;
   font-weight: 600;
   margin-bottom: 10px;
 }
 
 .timeline-card-description {
-  color: #555;
+  color: var(--text-secondary);
   line-height: 1.5;
   font-size: 0.95rem;
 }
@@ -252,14 +428,14 @@
 }
 
 .experience-title {
-  font-size: 2.25rem;              
-  font-weight: 700;                
-  text-align: center;              
-  color: #0f172a;                  
-  margin-bottom: 2rem;            
+  font-size: 2.25rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--text-primary);
+  margin-bottom: 2rem;
   position: relative;
   line-height: 1.2;
-  letter-spacing: -0.5px;        
+  letter-spacing: -0.5px;
   margin-top: 20px;
 }
 
@@ -268,7 +444,7 @@
   display: block;
   width: 60px;
   height: 4px;
-  background-color: #0ea5e9;      /* Accent line */
+  background-color: var(--accent-color);
   border-radius: 2px;
   margin: 0.5rem auto 0 auto;     /* Centered underline */
 }
@@ -292,26 +468,25 @@
 }
 
 /* Modern Header Section */
-.welcome-section {
+#hero {
   position: relative;
   height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(to bottom, var(--bg-base), var(--bg-elevated));
   overflow: hidden;
   min-height: 100vh;     /* Ensures section fills the whole screen */
-  display: flex;
   flex-direction: column;
 }
 
-.background-animation {
+#heroBG {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0.3;
+  opacity: 0.15;
   z-index: 1;
 }
 
@@ -323,9 +498,13 @@
 
 .shape {
   position: absolute;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 50%;
-  animation: float 6s ease-in-out infinite;
+  animation: float 10s ease-in-out infinite;
+  filter: blur(40px);
+  --px: 0px;
+  --py: 0px;
+  transform: translate(var(--px), var(--py));
 }
 
 .shape-1 {
@@ -381,9 +560,35 @@
   position: relative;
   z-index: 2;
   text-align: center;
-  color: white;
+  color: var(--text-primary);
   max-width: 800px;
   padding: 0 20px;
+}
+
+.glass-panel {
+  background: var(--bg-elevated);
+  border-radius: 16px;
+  padding: 40px 30px;
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border-hairline);
+  box-shadow: var(--shadow-1);
+}
+
+.hero-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin: 0 auto 20px;
+  display: block;
+  filter: grayscale(100%);
+  transition: filter 0.3s ease, border-color 0.3s ease;
+  border: 3px solid var(--border-hairline);
+}
+
+.hero-avatar:hover {
+  filter: none;
+  border-color: var(--accent-solid);
 }
 
 .main-title {
@@ -395,76 +600,110 @@
   font-size: 1.5rem;
   font-weight: 300;
   margin-bottom: 10px;
-  opacity: 0.9;
+  color: var(--text-secondary);
+}
+
+.hero-tagline {
+  font-size: 1.1rem;
+  font-family: 'Inter', sans-serif;
+  margin-bottom: 20px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.company-tag {
+  margin-bottom: 25px;
+}
+
+.company-tag a {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  color: var(--chip-text);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.company-tag a:hover {
+  background: var(--accent-soft);
+  color: var(--accent-solid);
+}
+
+.hero-bio {
+  font-size: 1rem;
+  line-height: 1.6;
+  margin-bottom: 20px;
+  color: var(--text-secondary);
+}
+
+
+/* Hero metrics */
+.hero-metrics {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin: 0 0 25px;
+  flex-wrap: wrap;
+}
+
+.metric {
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: 12px;
+  padding: 10px 16px;
+  text-align: center;
+  min-width: 90px;
+  box-shadow: var(--shadow-1);
+}
+
+.metric-number {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent-solid);
+}
+
+.metric-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.trusted-badges {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 25px;
+}
+
+.trusted-badges img {
+  width: 32px;
+  height: 32px;
+  filter: grayscale(100%);
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.trusted-badges img:hover {
+  opacity: 1;
 }
 
 .name {
   display: block;
   font-size: 4rem;
   font-weight: 700;
-  background: linear-gradient(45deg, #ffffff, #f0f8ff, #e6f3ff);
+  background: linear-gradient(45deg, var(--text-primary), var(--text-secondary));
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  animation: nameGlow 3s ease-in-out infinite alternate;
+  color: transparent;
 }
 
-@keyframes nameGlow {
-  0% {
-    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  }
-  100% {
-    text-shadow: 0 0 20px rgba(255,255,255,0.5);
-  }
-}
 
-.title-section {
-  margin-bottom: 30px;
-}
 
-.primary-title {
-  font-size: 1.8rem;
-  font-weight: 600;
-  margin-bottom: 15px;
-  color: #f0f8ff;
-}
 
-.company-info {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  flex-wrap: wrap;
-}
 
-.company-name {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.company-link {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 25px;
-  text-decoration: none;
-  color: white;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-.company-link:hover {
-  background: rgba(255, 255, 255, 0.3);
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-}
-
-.role-tags {
+.skill-tags {
   display: flex;
   justify-content: center;
   gap: 15px;
@@ -472,28 +711,20 @@
   flex-wrap: wrap;
 }
 
-.role-tag {
-  padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: 20px;
-  font-size: 0.9rem;
+.skill-tag {
+  padding: 6px 12px;
+  background: var(--chip-bg);
+  border-radius: 9999px;
+  font-size: 0.85rem;
   font-weight: 500;
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  animation: tagFloat 4s ease-in-out infinite;
+  border: 1px solid var(--chip-border);
+  color: var(--chip-text);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.role-tag:nth-child(1) { animation-delay: 0s; }
-.role-tag:nth-child(2) { animation-delay: 1s; }
-.role-tag:nth-child(3) { animation-delay: 2s; }
-
-@keyframes tagFloat {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-5px);
-  }
+.skill-tag:hover {
+  background: var(--accent-soft);
+  transform: scale(1.05);
 }
 
 .header-actions {
@@ -505,56 +736,60 @@
 }
 
 .cta-button {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 10px;
-  padding: 15px 30px;
-  border-radius: 30px;
+  padding: 12px 28px;
+  border-radius: 8px;
   text-decoration: none;
   font-weight: 600;
   font-size: 1rem;
-  transition: all 0.3s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  box-shadow: var(--shadow-1);
+  color: var(--text-primary);
   position: relative;
   overflow: hidden;
 }
 
-.cta-button::before {
+.cta-button::after {
   content: '';
   position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
-  transition: left 0.5s;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid var(--accent-solid);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+  pointer-events: none;
 }
 
-.cta-button:hover::before {
-  left: 100%;
+.cta-button:hover {
+  transform: scale(1.02);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
+}
+
+.cta-button:hover::after {
+  transform: scaleX(1);
 }
 
 .cta-button.primary {
-  background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-  color: white;
-  box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
+  border: none;
 }
 
 .cta-button.primary:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 25px rgba(255, 107, 107, 0.6);
+  background: var(--accent-hover);
 }
 
 .cta-button.secondary {
   background: transparent;
-  color: white;
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(10px);
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
 }
 
 .cta-button.secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.8);
-  transform: translateY(-3px);
+  background: var(--accent-soft);
 }
 
 .scroll-indicator {
@@ -565,23 +800,24 @@
 }
 
 .down-arrow {
-  border: solid rgba(255, 255, 255, 0.7);
-  border-width: 0 2px 2px 0;
+  width: 12px;
+  height: 12px;
+  border-width: 0 3px 3px 0;
+  border-style: solid;
+  border-color: var(--accent-solid);
   display: inline-block;
-  padding: 8px;
+  padding: 10px;
   transform: rotate(45deg);
-  animation: arrowBounce 2s infinite;
+  animation: arrowBounce 2.5s infinite ease-in-out;
+  opacity: 0;
 }
 
 @keyframes arrowBounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%, 100% {
     transform: rotate(45deg) translateY(0);
   }
-  40% {
-    transform: rotate(45deg) translateY(-10px);
-  }
-  60% {
-    transform: rotate(45deg) translateY(-5px);
+  50% {
+    transform: rotate(45deg) translateY(1px);
   }
 }
 
@@ -607,69 +843,24 @@
   }
 }
 
-/* Remove old welcome section styles */
-.welcome-section a{
-  font-weight: 500;
-  text-decoration: underline;
-  
-  font-size: 16px;
-  position: relative;
-  color: #333;
-}
-
-.storelx-web{
-  font-weight: 100;
-  text-decoration: underline;
-  font-size: 10px;
-  position: relative;
-  color: #b9b1b1;
-}
-
-.ceo-text {
-  font-size: 15px;
-  color: #666;
-  position: relative;
-  top: 0px;
-}
-
 /* Styling for the "About Me" section */
 .about-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
   padding: 80px 0;
-  position: relative;
-  overflow: hidden;
 }
 
 .about-section .content-container {
   max-width: 1000px;
   margin: 0 auto;
   padding: 2rem 1rem;
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 25px;
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  position: relative;
-  z-index: 1;
-  transition: all 0.3s ease;
-  text-align: center;
-}
-
-.about-section .content-container:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 35px 70px rgba(0, 0, 0, 0.2);
 }
 
 .about-section h2 {
   font-size: 3rem;
-  color: #2c3e50;
   margin-bottom: 40px;
   text-align: center;
   font-weight: 700;
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  
 }
 
 .about-section h2::after {
@@ -677,7 +868,7 @@
   display: block;
   width: 80px;
   height: 4px;
-  background: linear-gradient(45deg, #667eea, #764ba2);
+  background: var(--accent-solid);
   margin: 15px auto 0;
   border-radius: 2px;
   animation: underlineGrow 1s ease-out;
@@ -728,7 +919,7 @@
 
 .highlight-item {
   background: rgba(102, 126, 234, 0.05);
-  border-left: 4px solid #764ba2;
+  border-left: 4px solid var(--accent-color);
   padding: 12px 16px;
   border-radius: 10px;
   font-size: 0.95rem;
@@ -749,7 +940,7 @@
   border-radius: 15px;
   padding: 30px;
   margin-bottom: 30px;
-  border-left: 4px solid #667eea;
+  border-left: 4px solid var(--accent-color);
   position: relative;
   transition: all 0.3s ease;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
@@ -773,7 +964,7 @@
 
 .about-card:hover {
   background: rgba(102, 126, 234, 0.1);
-  border-left-color: #764ba2;
+  border-left-color: var(--accent-color);
   transform: translateX(5px);
   box-shadow: 0 15px 40px rgba(102, 126, 234, 0.2);
 }
@@ -828,10 +1019,7 @@
 .stat-number {
   font-size: 2.5rem;
   font-weight: 700;
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent-color);
   margin-bottom: 8px;
   animation: countUp 1.5s ease-out;
 }
@@ -872,7 +1060,7 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #667eea, #764ba2, #f093fb);
+  background: var(--accent-color);
   border-radius: 15px 15px 0 0;
   transform: scaleX(0);
   transition: transform 0.3s ease;
@@ -956,7 +1144,8 @@
 /* Styling for the education timeline */
 .education-section {
   padding: 50px 0;
-  background-color: #f0f0f0;
+  background: var(--bg-base);
+  color: var(--text-primary);
   text-align: center; /* Centering the education content */
 }
 
@@ -982,7 +1171,7 @@
 .education-section .edu-year {
   width: 120px;
   font-weight: 700;
-  color: #333;
+  color: var(--text-secondary);
   text-align: right;
   margin-right: 20px;
   position: relative;
@@ -994,7 +1183,7 @@
   top: 0;
   bottom: 0;
   width: 2px;
-  background-color: #666;
+  background: var(--border-hairline);
 }
 
 .education-section .edu-details {
@@ -1006,27 +1195,16 @@
 .education-section .edu-details h3 {
   font-size: 22px;
   margin-bottom: 5px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .education-section .edu-details p {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
   margin: 0;
 }
 
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
-
-:root {
-  --white: #fff;
-  --black: #323135;
-  --crystal: #a8dadd;
-  --columbia-blue: #cee9e4;
-  --midnight-green: #01565b;
-  --yellow: #e5f33d;
-  --timeline-gradient: rgba(206, 233, 228, 1) 0%, rgba(206, 233, 228, 1) 50%,
-    rgba(206, 233, 228, 0) 100%;
-}
+/* removed duplicate root and font import */
 
 *,
 *::before,
@@ -1054,11 +1232,19 @@ img {
 
 body {
   font: normal 16px/1.5 "Inter", sans-serif;
-  background: var(--columbia-blue);
-  color: var(--black);
+  background: var(--bg-base);
+  color: var(--text-primary);
   margin: 0 0 50px 0;
   padding: 0;
   overflow-x: hidden;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Poppins", sans-serif;
+}
+
+code, pre {
+  font-family: "Fira Code", monospace;
 }
 
 /* Center section content and limit width */
@@ -1190,7 +1376,7 @@ body {
 .profile-container {
   width: 100%;
   min-height: 100vh;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--color-slate);
   padding: 80px 0;
   position: relative;
   overflow: hidden;
@@ -1366,7 +1552,7 @@ body {
   left: 0;
   right: 0;
   height: 5px;
-  background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #ffeaa7);
+  background: var(--accent-color);
   border-radius: 25px 25px 0 0;
 }
 
@@ -1386,7 +1572,7 @@ body {
   position: relative;
   width: 80px;
   height: 80px;
-  background: linear-gradient(135deg, #667eea, #764ba2);
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color));
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -1488,10 +1674,7 @@ body {
 .last-name {
   display: block;
   font-weight: 700;
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent-color);
 }
 
 .contact-role {
@@ -1548,7 +1731,7 @@ body {
 }
 
 .detail-value:hover {
-  color: #667eea;
+  color: var(--accent-color);
 }
 
 .social-links {
@@ -1623,25 +1806,25 @@ body {
 }
 
 .contact-btn.primary {
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  color: white;
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 
 .contact-btn.primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.6);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.25);
 }
 
 .contact-btn.secondary {
   background: transparent;
-  color: #667eea;
-  border: 2px solid #667eea;
+  color: var(--accent-solid);
+  border: 2px solid var(--accent-solid);
 }
 
 .contact-btn.secondary:hover {
-  background: #667eea;
-  color: white;
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
   transform: translateY(-2px);
 }
 
@@ -1723,7 +1906,7 @@ body {
   cursor: default;
   margin: 20px;
   margin-left:70px;
-  color:var(--columbia-blue);
+  color:var(--accent-color);
 }
 
 .back {
@@ -1777,7 +1960,8 @@ margin-top: 20px;
 }
 
 .projects-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--bg-base);
+  color: var(--text-primary);
   padding: 80px 0;
   margin: 60px 0;
   position: relative;
@@ -1806,7 +1990,7 @@ margin-top: 20px;
 .projects-header {
   text-align: center;
   margin-bottom: 60px;
-  color: white;
+  color: var(--text-primary);
 }
 
 .projects-header h2 {
@@ -1820,6 +2004,7 @@ margin-top: 20px;
   font-size: 1.2rem;
   opacity: 0.9;
   font-weight: 300;
+  color: var(--text-secondary);
 }
 
 .projects-grid {
@@ -1830,15 +2015,14 @@ margin-top: 20px;
 }
 
 .project-card {
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--bg-elevated);
   border-radius: 20px;
   padding: 30px;
   box-shadow: 0 20px 40px rgba(0,0,0,0.1);
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border-hairline);
 }
 
 .project-card::before {
@@ -1848,7 +2032,7 @@ margin-top: 20px;
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4);
+  background: var(--accent-color);
   border-radius: 20px 20px 0 0;
 }
 
@@ -1866,14 +2050,14 @@ margin-top: 20px;
 
 .project-card-header h3 {
   font-size: 1.5rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin: 0;
   font-weight: 600;
 }
 
 .project-date {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
+  background: linear-gradient(135deg, var(--accent-solid), var(--accent-solid));
+  color: var(--text-onAccent);
   padding: 5px 15px;
   border-radius: 20px;
   font-size: 0.9rem;
@@ -1881,7 +2065,7 @@ margin-top: 20px;
 }
 
 .project-location {
-  color: #7f8c8d;
+  color: var(--text-secondary);
   font-size: 0.95rem;
   margin-bottom: 15px;
   font-weight: 500;
@@ -1892,7 +2076,7 @@ margin-top: 20px;
 }
 
 .project-description p {
-  color: #34495e;
+  color: var(--text-secondary);
   line-height: 1.6;
   font-size: 1rem;
 }
@@ -1903,7 +2087,7 @@ margin-top: 20px;
 }
 
 .project-details li {
-  color: #34495e;
+  color: var(--text-secondary);
   line-height: 1.5;
   font-size: 0.95rem;
   list-style: disc;
@@ -1917,13 +2101,12 @@ margin-top: 20px;
 }
 
 .tech-tag {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-  color: white;
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
   padding: 5px 12px;
   border-radius: 15px;
   font-size: 0.8rem;
   font-weight: 500;
-  box-shadow: 0 2px 10px rgba(240, 147, 251, 0.3);
 }
 
 .project-actions {
@@ -1933,8 +2116,8 @@ margin-top: 20px;
 }
 
 .project-link {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
   padding: 12px 20px;
   border-radius: 25px;
   text-decoration: none;
@@ -1942,13 +2125,12 @@ margin-top: 20px;
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.3s ease;
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
+  transition: transform 0.3s ease;
 }
 
 .project-link:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.6);
+  background: var(--accent-hover);
 }
 
 /* Responsive Design for Projects */
@@ -1979,7 +2161,8 @@ margin-top: 20px;
 
 /* Modern Skills Section */
 .skills-main-section {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--bg-base);
+  color: var(--text-primary);
   padding: 80px 0;
   position: relative;
   overflow: hidden;
@@ -2007,24 +2190,23 @@ margin-top: 20px;
 .skills-header {
   text-align: center;
   margin-bottom: 60px;
-  color: white;
+  color: var(--text-primary);
 }
 
 .skills-header h2 {
   font-size: 3.5rem;
   font-weight: 700;
   margin-bottom: 15px;
-  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-  background: linear-gradient(45deg, #ffffff, #f0f8ff);
+  background: linear-gradient(45deg, #e5e7eb, #9ca3af);
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: transparent;
 }
 
 .skills-header p {
   font-size: 1.3rem;
   opacity: 0.9;
   font-weight: 300;
+  color: var(--text-secondary);
 }
 
 .skills-content {
@@ -2034,17 +2216,17 @@ margin-top: 20px;
 
 /* Technical Skills */
 .technical-skills, .professional-skills {
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--bg-elevated);
   border-radius: 25px;
   padding: 40px;
   box-shadow: 0 25px 50px rgba(0,0,0,0.15);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--border-hairline);
+  color: var(--text-primary);
 }
 
 .technical-skills h3, .professional-skills h3 {
   font-size: 2.2rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin-bottom: 30px;
   display: flex;
   align-items: center;
@@ -2063,10 +2245,10 @@ margin-top: 20px;
 }
 
 .skill-category {
-  background: rgba(248, 249, 250, 0.8);
+  background: var(--bg-elevated);
   border-radius: 20px;
   padding: 30px;
-  border: 2px solid rgba(102, 126, 234, 0.1);
+  border: 1px solid var(--border-hairline);
   transition: all 0.3s ease;
 }
 
@@ -2078,7 +2260,7 @@ margin-top: 20px;
 
 .skill-category h4 {
   font-size: 1.4rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin-bottom: 25px;
   text-align: center;
   font-weight: 600;
@@ -2093,7 +2275,7 @@ margin-top: 20px;
   transform: translateX(-50%);
   width: 50px;
   height: 3px;
-  background: linear-gradient(45deg, #667eea, #764ba2);
+  background: var(--accent-color);
   border-radius: 2px;
 }
 
@@ -2104,7 +2286,7 @@ margin-top: 20px;
 }
 
 .skill-item {
-  background: white;
+  background: var(--bg-elevated);
   border-radius: 15px;
   padding: 20px;
   box-shadow: 0 5px 15px rgba(0,0,0,0.08);
@@ -2125,19 +2307,19 @@ margin-top: 20px;
 
 .skill-name {
   font-weight: 600;
-  color: #2c3e50;
+  color: var(--text-primary);
   font-size: 1.1rem;
 }
 
 .skill-percentage {
   font-weight: 700;
-  color: #667eea;
+  color: var(--accent-solid);
   font-size: 1rem;
 }
 
 .skill-bar {
   height: 8px;
-  background: #e9ecef;
+  background: var(--border-hairline);
   border-radius: 10px;
   overflow: hidden;
   position: relative;
@@ -2180,13 +2362,13 @@ margin-top: 20px;
 }
 
 .soft-skill-card {
-  background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+  background: var(--bg-elevated);
   border-radius: 20px;
   padding: 30px;
   text-align: center;
   box-shadow: 0 10px 30px rgba(0,0,0,0.1);
   transition: all 0.3s ease;
-  border: 2px solid transparent;
+  border: 1px solid var(--border-hairline);
   position: relative;
   overflow: hidden;
 }
@@ -2198,7 +2380,7 @@ margin-top: 20px;
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, #667eea, #764ba2, #f093fb, #f5576c);
+  background: var(--accent-color);
   border-radius: 20px 20px 0 0;
 }
 
@@ -2216,13 +2398,13 @@ margin-top: 20px;
 
 .soft-skill-card h4 {
   font-size: 1.3rem;
-  color: #2c3e50;
+  color: var(--text-primary);
   margin-bottom: 12px;
   font-weight: 600;
 }
 
 .soft-skill-card p {
-  color: #6c757d;
+  color: var(--text-secondary);
   line-height: 1.6;
   font-size: 0.95rem;
 }
@@ -2294,3 +2476,178 @@ margin-top: 20px;
   }
 }
 
+/* About section redesign */
+.about-section {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  padding: 80px 0;
+}
+
+.about-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  gap: 40px;
+  position: relative;
+}
+
+.about-bio {
+  flex: 1;
+}
+
+.about-bio p {
+  margin-bottom: 1rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.principles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 1.5rem 0;
+}
+
+.chip[data-principle] {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 16px;
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  border: 1px solid var(--chip-border);
+  font-size: 0.85rem;
+  cursor: default;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.chip[data-principle] .chip-icon {
+  opacity: 0;
+  width: 0;
+  transition: opacity 0.2s ease, width 0.2s ease;
+}
+
+.chip[data-principle]:hover {
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
+}
+
+.chip[data-principle]:hover .chip-icon {
+  opacity: 1;
+  width: 1em;
+}
+
+.achievements {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.achievement-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  border: 1px solid var(--chip-border);
+  font-size: 0.85rem;
+  transition: background 0.2s ease;
+}
+
+.achievement-pill:hover {
+  background: var(--accent-soft);
+}
+
+.about-divider {
+  width: 2px;
+  background: linear-gradient(var(--accent-solid), var(--accent-hover));
+  background-size: 200% 200%;
+  animation: aboutDividerFlow 4s linear infinite;
+}
+
+@keyframes aboutDividerFlow {
+  from { background-position: 0% 0%; }
+  to { background-position: 0% 100%; }
+}
+
+.about-metrics {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.metric-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-hairline);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+  box-shadow: var(--shadow-1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.metric-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent-solid);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.2);
+}
+
+.metric-number {
+  color: var(--accent-solid);
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.metric-label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.tech-timeline {
+  margin-top: 40px;
+  display: flex;
+  gap: 40px;
+  justify-content: center;
+}
+
+.timeline-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.timeline-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-solid);
+  margin-bottom: 4px;
+}
+
+.timeline-year {
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.timeline-tech {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+  .about-container {
+    flex-direction: column;
+    gap: 30px;
+  }
+  .about-divider {
+    display: none;
+  }
+  .about-metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/Resume.js
+++ b/Resume.js
@@ -1,29 +1,172 @@
-// Add smooth scrolling to navigate to sections
-document.getElementById('scroll-down').addEventListener('click', function() {
-  const target = document.getElementById('about');
-  if (target) {
-    target.scrollIntoView({
-      behavior: 'smooth'
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const savedTheme = localStorage.getItem('theme');
+document.documentElement.setAttribute('data-theme', savedTheme || (prefersDark ? 'dark' : 'light'));
+
+document.addEventListener('DOMContentLoaded', () => {
+  const codeBlock = document.getElementById('code-block');
+  const navbar = document.querySelector('.navbar');
+  const codeText = [
+    '<section id="hero">',
+    '  <h1>Noureldeen Fahmy</h1>',
+    '</section>'
+  ].join('\n');
+  let idx = 0;
+  (function type() {
+    if (idx < codeText.length) {
+      codeBlock.textContent += codeText.charAt(idx);
+      idx++;
+      setTimeout(type, 20);
+    }
+  })();
+
+  runHeroAnimations();
+  runAboutAnimations();
+  shuffleMetrics();
+
+  document.getElementById('scrollCue').addEventListener('click', () => {
+    const target = document.getElementById('about');
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+
+  window.addEventListener('scroll', () => {
+    navbar.classList.toggle('scrolled', window.scrollY > 10);
+  });
+
+  document.querySelectorAll('.nav-link').forEach(link => {
+    link.addEventListener('click', () => {
+      document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
+      link.classList.add('active');
+    });
+  });
+
+  const themeToggle = document.getElementById('theme-toggle');
+  themeToggle.addEventListener('click', () => {
+    const root = document.documentElement;
+    const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+});
+
+const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+function runHeroAnimations() {
+  if (prefersReduced) {
+    gsap.set(["#hero", "[data-hero-el]"], { opacity: 1, y: 0, clearProps: "all" });
+    return;
+  }
+
+  gsap.registerPlugin(ScrollTrigger);
+  const tl = gsap.timeline({ defaults: { ease: "power3.out" } });
+
+  tl.to("#code-intro", { opacity: 1, duration: 0.2 })
+    .to("#code-intro", { opacity: 0, filter: "blur(10px)", pointerEvents: "none", duration: 0.6, delay: 1.3 });
+
+  tl.fromTo("#heroCard", { opacity: 0, y: 16, filter: "blur(8px)" },
+                     { opacity: 1, y: 0, filter: "blur(0px)", duration: 0.8 }, "<0.1");
+
+    tl.from("[data-hero-h1]", { opacity: 0, y: 10, duration: 0.6 }, "-=0.2")
+      .from("[data-hero-sub]", { opacity: 0, y: 10, duration: 0.5 }, "-=0.2")
+      .from("[data-chip]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
+      .from("[data-avatar]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
+      .from("[data-bio]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
+      .from("[data-metric]", { opacity: 0, y: 10, stagger: 0.08, duration: 0.4 }, "-=0.2")
+      .call(() => animateMetrics(), null, "-=0.1")
+      .from("[data-badge]", { opacity: 0, y: 8, stagger: 0.08, duration: 0.3 }, "-=0.2")
+      .from("[data-skill]", { opacity: 0, y: 10, stagger: 0.08, duration: 0.4 }, "-=0.2")
+      .from("[data-cta]", { opacity: 0, y: 8, stagger: 0.08, duration: 0.35 }, "-=0.2")
+      .to("#scrollCue", { opacity: 1, duration: 0.3 }, "-=0.1");
+
+  const card = document.querySelector("#heroCard");
+  if (window.matchMedia("(pointer: fine)").matches && card) {
+    card.addEventListener("mousemove", (e) => {
+      const r = card.getBoundingClientRect();
+      const x = (e.clientX - (r.left + r.width / 2)) / r.width;
+      const y = (e.clientY - (r.top + r.height / 2)) / r.height;
+      gsap.to("#heroBG", { x: x * 8, y: y * 6, duration: 0.3, overwrite: true });
+      gsap.to("[data-hero-h1]", { x: x * 3, y: y * 2, duration: 0.3, overwrite: true });
     });
   }
-});
 
-// Reveal the clean strip for "About Me" section on scroll
-window.addEventListener('scroll', function() {
-  const aboutSection = document.getElementById('about');
-  if (aboutSection) {
-    const rect = aboutSection.getBoundingClientRect();
-    if (rect.top < window.innerHeight * 0.8) {
-      aboutSection.classList.add('scrolled');
-    }
+  const avatar = document.querySelector('[data-avatar]');
+  if (window.matchMedia('(pointer: fine)').matches && avatar) {
+    avatar.addEventListener('mousemove', (e) => {
+      const r = avatar.getBoundingClientRect();
+      const x = (e.clientX - (r.left + r.width / 2)) / r.width;
+      const y = (e.clientY - (r.top + r.height / 2)) / r.height;
+      gsap.to(avatar, { rotationY: x * 10, rotationX: -y * 10, duration: 0.3, transformPerspective: 500, overwrite: true });
+    });
+    avatar.addEventListener('mouseleave', () => {
+      gsap.to(avatar, { rotationY: 0, rotationX: 0, duration: 0.3 });
+    });
   }
-});
 
+  const btns = gsap.utils.toArray("[data-cta]");
+  btns.forEach((b) => {
+    b.addEventListener("mouseenter", () =>
+      gsap.to(b, { scale: 1.02, boxShadow: "0 10px 24px rgba(0,0,0,.18)", duration: 0.18, ease: "power2.out" })
+    );
+    b.addEventListener("mouseleave", () =>
+      gsap.to(b, { scale: 1.0, boxShadow: "0 4px 12px rgba(0,0,0,.12)", duration: 0.18, ease: "power2.out" })
+    );
+  });
+}
+
+function runAboutAnimations() {
+  if (prefersReduced) {
+    gsap.set('#about .about-bio, #about .metric-card, #about .achievement-pill', { opacity: 1, x: 0, y: 0, clearProps: 'all' });
+    return;
+  }
+  gsap.registerPlugin(ScrollTrigger);
+  const tl = gsap.timeline({
+    scrollTrigger: {
+      trigger: '#about',
+      start: 'top 80%'
+    },
+    defaults: { ease: 'power3.out' }
+  });
+  tl.from('#about .about-bio', { opacity: 0, x: -30, duration: 0.8 })
+    .from('#about .metric-card', { opacity: 0, x: 30, stagger: 0.08, duration: 0.6 }, '-=0.4')
+    .add(() => animateMetrics(document.querySelector('#about')))
+    .from('#about .achievement-pill', { opacity: 0, y: 20, scale: 0.8, stagger: 0.08, duration: 0.4 }, '-=0.2');
+}
+
+function shuffleMetrics() {
+  const container = document.querySelector('#about .about-metrics');
+  if (!container) return;
+  const rotate = () => {
+    const first = container.firstElementChild;
+    if (first && container.children.length > 1) {
+      container.appendChild(first);
+    }
+  };
+  setInterval(rotate, 5000);
+  container.addEventListener('mouseenter', rotate);
+}
+
+function animateMetrics(scope) {
+  (scope || document).querySelectorAll('[data-count]').forEach((el) => {
+    const end = parseInt(el.getAttribute('data-count'), 10);
+    const suffix = el.getAttribute('data-suffix') || '';
+    gsap.fromTo(el, { innerText: 0 }, {
+      innerText: end,
+      duration: 1.2,
+      ease: 'power1.out',
+      snap: { innerText: 1 },
+      onUpdate: function () {
+        el.textContent = Math.round(el.innerText) + suffix;
+      }
+    });
+  });
+}
+
+// Function to animate skill bars when they come into view
 window.onload = function() {
   animateSkillBars();
 };
 
-// Function to animate skill bars when they come into view
 function animateSkillBars() {
   const skillBars = document.querySelectorAll('.skill-progress');
   

--- a/index.html
+++ b/index.html
@@ -1,16 +1,26 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Welcome to Nour's Website</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="Resume.css">
 </head>
 
 <body>
-  <div class="welcome-section" id="welcome">
-    <div class="background-animation">
+  <div id="code-intro" class="code-intro"><pre id="code-block"></pre></div>
+  <nav class="navbar">
+    <a href="#hero" class="nav-link active">Home</a>
+    <a href="#about" class="nav-link">About</a>
+    <a href="#card" class="nav-link">Contact</a>
+    <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+  </nav>
+  <div class="welcome-section" id="hero">
+    <div class="background-animation" id="heroBG">
       <div class="floating-shapes">
         <div class="shape shape-1"></div>
         <div class="shape shape-2"></div>
@@ -19,98 +29,134 @@
         <div class="shape shape-5"></div>
       </div>
     </div>
-    
+
     <div class="header-content">
-      <div class="profile-intro">
-        <h1 class="main-title">
+      <div class="profile-intro glass-panel" id="heroCard" role="region" aria-label="Intro">
+        <img src="images/IMG_8098.jpeg" alt="Noureldeen Fahmy" class="hero-avatar" data-avatar>
+        <h1 class="main-title" data-hero-h1>
           <span class="greeting">Hello, I'm</span>
-          <span class="name">Noureldeen Fahmy</span>
+          <span class="name" id="hero-name">Noureldeen Fahmy</span>
         </h1>
-        
-        <div class="title-section">
-          <div class="company-info">
-            <span class="company-name">Storelx</span>
-            <a href="https://www.storelx.com" target="_blank" class="company-link">
-              <span class="link-icon">🌐</span>
-              <span class="link-text">www.storelx.com</span>
-            </a>
+        <p class="hero-tagline" data-hero-sub>Full-stack developer &amp; data scientist</p>
+        <div class="company-tag">
+          <a href="https://www.storelx.com" target="_blank" data-chip>Storelx</a>
+        </div>
+        <p class="hero-bio" data-bio>I build polished, scalable web platforms and data products that power real businesses.</p>
+        <div class="hero-metrics">
+          <div class="metric" data-metric>
+            <span class="metric-number" data-count="100" data-suffix="+">0</span>
+            <span class="metric-label">Active Users</span>
+          </div>
+          <div class="metric" data-metric>
+            <span class="metric-number" data-count="40" data-suffix="%">0</span>
+            <span class="metric-label">Faster API</span>
+          </div>
+          <div class="metric" data-metric>
+            <span class="metric-number" data-count="85" data-suffix="%">0</span>
+            <span class="metric-label">ML Accuracy</span>
           </div>
         </div>
-        
-        <div class="role-tags">
-          <span class="role-tag">Full-Stack Developer</span>
-          <span class="role-tag">Data Scientist</span>
-          <span class="role-tag">Team Leader</span>
+        <div class="trusted-badges">
+          <img src="images/github.png" alt="GitHub" data-badge>
+          <img src="images/icons8-linkedin-96.png" alt="LinkedIn" data-badge>
         </div>
-        
+        <div class="skill-tags">
+          <span class="skill-tag" data-skill>React</span>
+          <span class="skill-tag" data-skill>Node.js</span>
+          <span class="skill-tag" data-skill>Python</span>
+          <span class="skill-tag" data-skill>AWS</span>
+        </div>
         <div class="header-actions">
-          <a href="#card" class="cta-button primary">
+          <a href="#card" class="cta-button primary" data-cta aria-label="Contact me">
             <span class="button-icon">📧</span>
             <span class="button-text">Contact Me</span>
           </a>
-          <a href="#about" class="cta-button secondary">
+          <a href="#about" class="cta-button secondary" data-cta aria-label="Learn more about me">
             <span class="button-icon">👤</span>
             <span class="button-text">About Me</span>
           </a>
         </div>
       </div>
-      
+
       <div class="scroll-indicator">
-        <div class="down-arrow" id="scroll-down"></div>
+        <div class="down-arrow" id="scrollCue"></div>
       </div>
     </div>
   </div>
 
-  <!-- About Me Section -->
-  <section class="about-section fade-section" id="about">
-    <div class="content-container">
-      <h2>About Me</h2>
-      <div class="about-flex">
-        <div class="about-left">
-          <div class="about-intro">
-            <p>
-              I'm <strong>Noureldeen Fahmy</strong>, a Computer Science Honours student at Memorial University of Newfoundland, graduating in 2025. I specialize in building scalable full-stack web platforms and data-driven applications.
-            </p>
-            <p>
-              With a solid background in full-stack development and data science, I've led agile teams, developed intelligent data pipelines, and built real-world products used by thousands.
-            </p>
-            <p>
-              My mission is simple: combine great engineering with actionable data to solve real problems. I love working in collaborative environments where I can continuously grow and deliver impact.
-            </p>
-          </div>
-  
-          <div class="about-highlights">
-            <div class="highlight-item">🌟 Built & led a P2P storage marketplace (Storelx)</div>
-            <div class="highlight-item">📉 Reduced API response time by 40%</div>
-            <div class="highlight-item">📊 85% accuracy in ML forecasting</div>
-            <div class="highlight-item">👨‍💻 Led team of 3+ devs in agile sprints</div>
-          </div>
-        </div>
-  
-        <!-- Right: Stats -->
-        <div class="about-right">
-          <div class="stats-grid">
-            <div class="stat-item">
-              <div class="stat-number">100+</div>
-              <div class="stat-label">Active Users</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">5+</div>
-              <div class="stat-label">Projects Completed</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">3+</div>
-              <div class="stat-label">Years of Experience</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">95%</div>
-              <div class="stat-label">Sprint Completion</div>
-            </div>
-          </div>
-        </div>
+
+<!-- About Me Section -->
+<section class="about-section fade-section" id="about">
+  <div class="about-container">
+    <div class="about-bio">
+      <p>
+        I'm <strong>Noureldeen Fahmy</strong>, a full-stack developer and data enthusiast who loves turning complex
+        ideas into <strong>scalable platforms</strong> and <strong>insightful products</strong>.
+      </p>
+      <p>
+        From <strong>React</strong> dashboards to <strong>Node.js</strong> APIs and <strong>AWS</strong> cloud
+        pipelines, I focus on reliability and performance without sacrificing polish.
+      </p>
+      <p>
+        I thrive in collaborative teams, shipping features that matter and continuously refining the craft of building for
+        the web.
+      </p>
+
+      <div class="principles">
+        <span class="chip" data-principle><span class="chip-icon">🛡️</span><span class="chip-text">Reliability</span></span>
+        <span class="chip" data-principle><span class="chip-icon">⚡</span><span class="chip-text">Performance</span></span>
+        <span class="chip" data-principle><span class="chip-icon">🤝</span><span class="chip-text">Collaboration</span></span>
+        <span class="chip" data-principle><span class="chip-icon">🚀</span><span class="chip-text">Innovation</span></span>
+      </div>
+
+      <div class="achievements">
+        <div class="achievement-pill"><span class="icon">🚀</span>Built marketplace</div>
+        <div class="achievement-pill"><span class="icon">⚡</span>Cut API latency 40%</div>
+        <div class="achievement-pill"><span class="icon">📊</span>85% ML accuracy</div>
+        <div class="achievement-pill"><span class="icon">🤝</span>Led 3+ devs</div>
       </div>
     </div>
-  </section>
+
+    <div class="about-divider" aria-hidden="true"></div>
+
+    <div class="about-metrics">
+      <div class="metric-card" data-about-metric>
+        <span class="metric-number" data-count="100" data-suffix="+">0</span>
+        <span class="metric-label">Active Users</span>
+      </div>
+      <div class="metric-card" data-about-metric>
+        <span class="metric-number" data-count="5" data-suffix="+">0</span>
+        <span class="metric-label">Projects</span>
+      </div>
+      <div class="metric-card" data-about-metric>
+        <span class="metric-number" data-count="3" data-suffix="+">0</span>
+        <span class="metric-label">Years Experience</span>
+      </div>
+      <div class="metric-card" data-about-metric>
+        <span class="metric-number" data-count="95" data-suffix="%">0</span>
+        <span class="metric-label">Sprint Completion</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="tech-timeline">
+    <div class="timeline-item">
+      <span class="timeline-dot"></span>
+      <span class="timeline-year">2021</span>
+      <span class="timeline-tech">CS Degree Started</span>
+    </div>
+    <div class="timeline-item">
+      <span class="timeline-dot"></span>
+      <span class="timeline-year">2022</span>
+      <span class="timeline-tech">Launched Storelx</span>
+    </div>
+    <div class="timeline-item">
+      <span class="timeline-dot"></span>
+      <span class="timeline-year">2023</span>
+      <span class="timeline-tech">ML Forecasting 85%+</span>
+    </div>
+  </div>
+</section>
   
   <!-- Education Section -->
   <div class="education-section fade-section" id="education">
@@ -618,6 +664,8 @@
   </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
   <script src="Resume.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- introduce semantic color tokens for dark and light modes and map legacy variables
- persist theme preference with localStorage and system defaults
- restyle chips, skill tags, and CTAs to consume new tokens and accent styles
- apply token-based colors across education, experience, projects, and skills sections for full theme coverage
- enrich hero with avatar, bio, highlight metrics, and trusted badges with GSAP reveal sequence
- add animated KPI counters, skill-chip scaling, and interactive avatar tilt
- redesign About Me into a two-column narrative with principle chips, metric cards, achievement pills, and timeline with count-up metrics and auto-reordering

## Testing
- `npm test` (fails: Could not read package.json: ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_689e236266bc833289204be621728957