### PR TITLE
feat: merge about section into new full-width hero

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -20,6 +20,8 @@
   --chip-border:transparent;
   --chip-text:#E9EDF3;
 
+  --hero-bg:#0F1115;
+
   --code-bg:#0C0F14;
   --code-inline-bg:rgba(255,255,255,0.06);
   --focus-ring:#2F6EEA;
@@ -28,7 +30,7 @@
 }
 
 :root[data-theme='light']{
-  --bg-base:#F7F9FC;
+  --bg-base:#F7F7F5;
   --bg-elevated:#FFFFFF;
   --bg-overlay:rgba(0,0,0,0.06);
 
@@ -37,7 +39,7 @@
   --text-muted:#5D6676;
   --text-onAccent:#FFFFFF;
 
-  --border-hairline:#E4E8EF;
+  --border-hairline:#E6E6EA;
   --border-strong:#CBD2D9;
 
   --accent-solid:#2F6EEA;
@@ -45,8 +47,10 @@
   --accent-hover:#255FDB;
 
   --chip-bg:#F0F3FA;
-  --chip-border:#E4E8EF;
+  --chip-border:#E6E6EA;
   --chip-text:#0E1116;
+
+  --hero-bg:#F7F7F5;
 
   --code-bg:#F4F6FB;
   --code-inline-bg:#EEF2F9;
@@ -80,29 +84,298 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+/* Developer hero section */
+.hero {
+  background: var(--bg-base);
+  color: var(--text-primary);
+}
+
+.hero-canvas {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 60px 40px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 16px;
+  background: var(--bg-elevated);
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-shadow: 0 24px 32px rgba(0,0,0,0.25);
+}
+
+.hero-canvas::before {
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:radial-gradient(circle at top left, rgba(255,255,255,0.06), transparent 70%);
+  pointer-events:none;
+}
+
+.hero-grid {
+  display:grid;
+  grid-template-columns:repeat(12,1fr);
+  column-gap:60px;
+  align-items:center;
+  margin-bottom:60px;
+}
+
+.hero-left {
+  grid-column:1 / span 7;
+}
+
+.hero-eyebrow {
+  text-transform:uppercase;
+  letter-spacing:0.06em;
+  font-size:0.875rem;
+  color:var(--text-muted);
+  margin-bottom:20px;
+}
+
+.hero-heading {
+  margin:0 0 24px;
+  line-height:1.1;
+}
+
+.hero-name {
+  font-family:'Poppins', sans-serif;
+  font-weight:900;
+  font-size:64px;
+  position:relative;
+}
+
+.hero-name:hover::after {
+  content:attr(data-tooltip);
+  position:absolute;
+  bottom:-32px;
+  left:0;
+  font-family:'Fira Code', monospace;
+  font-size:14px;
+  background:var(--bg-elevated);
+  padding:4px 8px;
+  border:1px solid var(--border-hairline);
+  border-radius:4px;
+  white-space:nowrap;
+  color:var(--text-secondary);
+}
+
+.hero-role {
+  display:block;
+  font-family:'Playfair Display', serif;
+  font-style:italic;
+  font-size:56px;
+  font-weight:600;
+}
+
+.hero-subhead {
+  font-size:20px;
+  line-height:1.6;
+  max-width:480px;
+  margin-bottom:24px;
+  color:var(--text-secondary);
+}
+
+.hero-about {
+  max-width:70ch;
+  margin-bottom:32px;
+}
+
+.hero-about p {
+  font-size:16px;
+  line-height:1.7;
+  margin-bottom:12px;
+  color:var(--text-secondary);
+}
+
+.hero-about p:last-child { margin-bottom:0; }
+
+.hero-cta {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:12px 24px;
+  background:var(--accent-solid);
+  color:var(--text-onAccent);
+  border-radius:9999px;
+  text-decoration:none;
+  font-weight:500;
+  transition:transform 0.2s ease, background 0.2s ease;
+}
+
+.hero-cta:hover {
+  transform:scale(1.02);
+  background:var(--accent-hover);
+}
+
+.cta-arrow { transition:transform 0.2s ease; }
+
+.hero-cta:hover .cta-arrow { transform:translateX(3px); }
+
+.hero-links {
+  margin-top:16px;
+  display:flex;
+  gap:16px;
+}
+
+.hero-link {
+  font-size:0.875rem;
+  color:var(--text-muted);
+  text-decoration:none;
+  position:relative;
+}
+
+.hero-link::after {
+  content:'→';
+  margin-left:4px;
+  transition:transform 0.2s ease;
+}
+
+.hero-link:hover::after { transform:translateX(3px); }
+
+.hero-right {
+  grid-column:8 / span 5;
+  display:flex;
+  align-items:center;
+  gap:40px;
+  position:relative;
+}
+
+.portrait-wrapper {
+  position:relative;
+  width:320px;
+  height:420px;
+}
+
+.portrait-wrapper .shield {
+  position:absolute;
+  inset:-32px;
+  border-radius:40px;
+  background:radial-gradient(circle at 30% 30%, var(--bg-elevated), var(--bg-base));
+  box-shadow:0 32px 32px rgba(0,0,0,0.25);
+  z-index:-1;
+}
+
+.portrait {
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  border-radius:16px;
+  display:block;
+}
+
+.code-panel {
+  position:absolute;
+  bottom:-24px;
+  left:-24px;
+  width:160px;
+  background:var(--bg-elevated);
+  border:1px solid var(--border-hairline);
+  border-radius:8px;
+  opacity:0.5;
+  overflow:hidden;
+  font-family:'Fira Code', monospace;
+  font-size:12px;
+  padding:8px;
+}
+
+.hero-stats {
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+  padding-left:40px;
+  border-left:1px solid rgba(255,255,255,0.12);
+}
+
+[data-theme='light'] .hero-stats {
+  border-left:1px solid rgba(0,0,0,0.12);
+}
+
+.stat-number {
+  font-size:32px;
+  font-weight:700;
+  transition:color 0.3s;
+}
+
+.stat-label {
+  font-size:12px;
+  text-transform:uppercase;
+  color:var(--text-muted);
+}
+
+.stat:hover .stat-number { color:var(--accent-solid); }
+
+.feature-row {
+  border-top:1px solid var(--border-hairline);
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+}
+
+.feature-block {
+  padding:24px 32px;
+  border-left:1px solid var(--border-hairline);
+  text-align:center;
+  transition:transform 0.2s ease;
+}
+
+.feature-block:first-child { border-left:none; }
+
+.feature-block h3 {
+  font-size:14px;
+  text-transform:uppercase;
+  font-weight:700;
+  margin-bottom:8px;
+}
+
+.feature-block p {
+  font-size:14px;
+  color:var(--text-muted);
+}
+
+.feature-block::after {
+  content:"";
+  display:block;
+  width:0;
+  height:1px;
+  background:var(--accent-solid);
+  margin:4px auto 0;
+  transition:width 0.2s ease;
+}
+
+.feature-block:hover {
+  transform:translateY(-4px);
+}
+
+.feature-block:hover::after { width:60%; }
+
+.hero-transition svg {
+  display:block;
+  width:100%;
+  height:80px;
+  color:var(--bg-base);
+}
+
+@media (max-width:1024px){
+  .hero-right{ flex-direction:column; }
+  .hero-stats{ padding-left:0; border-left:none; display:grid; grid-template-columns:repeat(2,1fr); gap:20px; width:100%; }
+  .stat{ text-align:center; }
+}
+
+@media (max-width:768px){
+  .hero-grid{ grid-template-columns:1fr; row-gap:40px; }
+  .hero-left{ grid-column:1/-1; text-align:center; }
+  .hero-right{ grid-column:1/-1; }
+  .hero-links{ justify-content:center; }
+  .feature-row{ grid-template-columns:repeat(2,1fr); }
+  .feature-block{ border-top:1px solid var(--border-hairline); }
+  .feature-block:nth-child(odd){ border-left:none; }
+  .feature-block:nth-child(-n+2){ border-top:none; }
+}
+
 :focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
-}
-
-/* Initial hero code intro */
-.code-intro {
-  position: fixed;
-  inset: 0;
-  background: var(--code-bg);
-  color: var(--accent-solid);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Fira Code', monospace;
-  font-size: 1rem;
-  z-index: 999;
-  opacity: 1;
-  transition: opacity 2.5s ease-in-out;
-}
-.code-intro.fade-out {
-  opacity: 0;
-  pointer-events: none;
 }
 
 code, .code-inline {
@@ -465,382 +738,6 @@ pre code {
 .fade-section.visible {
   opacity: 1;
   transform: translateY(0);
-}
-
-/* Modern Header Section */
-#hero {
-  position: relative;
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(to bottom, var(--bg-base), var(--bg-elevated));
-  overflow: hidden;
-  min-height: 100vh;     /* Ensures section fills the whole screen */
-  flex-direction: column;
-}
-
-#heroBG {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0.15;
-  z-index: 1;
-}
-
-.floating-shapes {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
-.shape {
-  position: absolute;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 50%;
-  animation: float 10s ease-in-out infinite;
-  filter: blur(40px);
-  --px: 0px;
-  --py: 0px;
-  transform: translate(var(--px), var(--py));
-}
-
-.shape-1 {
-  width: 80px;
-  height: 80px;
-  top: 20%;
-  left: 10%;
-  animation-delay: 0s;
-}
-
-.shape-2 {
-  width: 60px;
-  height: 60px;
-  top: 60%;
-  left: 80%;
-  animation-delay: 2s;
-}
-
-.shape-3 {
-  width: 100px;
-  height: 100px;
-  top: 80%;
-  left: 20%;
-  animation-delay: 4s;
-}
-
-.shape-4 {
-  width: 40px;
-  height: 40px;
-  top: 30%;
-  left: 70%;
-  animation-delay: 1s;
-}
-
-.shape-5 {
-  width: 120px;
-  height: 120px;
-  top: 10%;
-  left: 60%;
-  animation-delay: 3s;
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px) rotate(0deg);
-  }
-  50% {
-    transform: translateY(-20px) rotate(180deg);
-  }
-}
-
-.header-content {
-  position: relative;
-  z-index: 2;
-  text-align: center;
-  color: var(--text-primary);
-  max-width: 800px;
-  padding: 0 20px;
-}
-
-.glass-panel {
-  background: var(--bg-elevated);
-  border-radius: 16px;
-  padding: 40px 30px;
-  backdrop-filter: blur(6px);
-  border: 1px solid var(--border-hairline);
-  box-shadow: var(--shadow-1);
-}
-
-.hero-avatar {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  object-fit: cover;
-  margin: 0 auto 20px;
-  display: block;
-  filter: grayscale(100%);
-  transition: filter 0.3s ease, border-color 0.3s ease;
-  border: 3px solid var(--border-hairline);
-}
-
-.hero-avatar:hover {
-  filter: none;
-  border-color: var(--accent-solid);
-}
-
-.main-title {
-  margin-bottom: 30px;
-}
-
-.greeting {
-  display: block;
-  font-size: 1.5rem;
-  font-weight: 300;
-  margin-bottom: 10px;
-  color: var(--text-secondary);
-}
-
-.hero-tagline {
-  font-size: 1.1rem;
-  font-family: 'Inter', sans-serif;
-  margin-bottom: 20px;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.company-tag {
-  margin-bottom: 25px;
-}
-
-.company-tag a {
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 12px;
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  color: var(--chip-text);
-  text-decoration: none;
-  font-size: 0.8rem;
-  transition: background 0.3s ease, color 0.3s ease;
-}
-
-.company-tag a:hover {
-  background: var(--accent-soft);
-  color: var(--accent-solid);
-}
-
-.hero-bio {
-  font-size: 1rem;
-  line-height: 1.6;
-  margin-bottom: 20px;
-  color: var(--text-secondary);
-}
-
-
-/* Hero metrics */
-.hero-metrics {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  margin: 0 0 25px;
-  flex-wrap: wrap;
-}
-
-.metric {
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  border-radius: 12px;
-  padding: 10px 16px;
-  text-align: center;
-  min-width: 90px;
-  box-shadow: var(--shadow-1);
-}
-
-.metric-number {
-  display: block;
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--accent-solid);
-}
-
-.metric-label {
-  display: block;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-}
-
-.trusted-badges {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-  margin-bottom: 25px;
-}
-
-.trusted-badges img {
-  width: 32px;
-  height: 32px;
-  filter: grayscale(100%);
-  opacity: 0.8;
-  transition: opacity 0.2s ease;
-}
-
-.trusted-badges img:hover {
-  opacity: 1;
-}
-
-.name {
-  display: block;
-  font-size: 4rem;
-  font-weight: 700;
-  background: linear-gradient(45deg, var(--text-primary), var(--text-secondary));
-  -webkit-background-clip: text;
-  color: transparent;
-}
-
-
-
-
-.skill-tags {
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-  margin-bottom: 40px;
-  flex-wrap: wrap;
-}
-
-.skill-tag {
-  padding: 6px 12px;
-  background: var(--chip-bg);
-  border-radius: 9999px;
-  font-size: 0.85rem;
-  font-weight: 500;
-  border: 1px solid var(--chip-border);
-  color: var(--chip-text);
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.skill-tag:hover {
-  background: var(--accent-soft);
-  transform: scale(1.05);
-}
-
-.header-actions {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-  margin-bottom: 50px;
-  flex-wrap: wrap;
-}
-
-.cta-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 28px;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
-  box-shadow: var(--shadow-1);
-  color: var(--text-primary);
-  position: relative;
-  overflow: hidden;
-}
-
-.cta-button::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid var(--accent-solid);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
-  pointer-events: none;
-}
-
-.cta-button:hover {
-  transform: scale(1.02);
-  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
-}
-
-.cta-button:hover::after {
-  transform: scaleX(1);
-
-}
-
-.cta-button.primary {
-  background: var(--accent-solid);
-  color: var(--text-onAccent);
-  border: none;
-}
-
-.cta-button.primary:hover {
-  background: var(--accent-hover);
-}
-
-.cta-button.secondary {
-  background: transparent;
-  border: 1px solid var(--border-hairline);
-  color: var(--text-primary);
-}
-
-.cta-button.secondary:hover {
-  background: var(--accent-soft);
-}
-
-.scroll-indicator {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.down-arrow {
-  width: 12px;
-  height: 12px;
-  border-width: 0 3px 3px 0;
-  border-style: solid;
-  border-color: var(--accent-solid);
-  display: inline-block;
-  padding: 10px;
-  transform: rotate(45deg);
-  animation: arrowBounce 2.5s infinite ease-in-out;
-  opacity: 0;
-}
-
-@keyframes arrowBounce {
-  0%, 100% {
-    transform: rotate(45deg) translateY(0);
-  }
-  50% {
-    transform: rotate(45deg) translateY(1px);
-  }
-}
-
-/* Responsive Header */
-@media (max-width: 768px) {
-  .name {
-    font-size: 3rem;
-  }
-  
-  .header-actions {
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  .cta-button {
-    width: 200px;
-    justify-content: center;
-  }
-  
-  .company-info {
-    flex-direction: column;
-    gap: 10px;
-  }
 }
 
 /* Styling for the "About Me" section */

--- a/Resume.js
+++ b/Resume.js
@@ -3,30 +3,10 @@ const savedTheme = localStorage.getItem('theme');
 document.documentElement.setAttribute('data-theme', savedTheme || (prefersDark ? 'dark' : 'light'));
 
 document.addEventListener('DOMContentLoaded', () => {
-  const codeBlock = document.getElementById('code-block');
   const navbar = document.querySelector('.navbar');
-  const codeText = [
-    '<section id="hero">',
-    '  <h1>Noureldeen Fahmy</h1>',
-    '</section>'
-  ].join('\n');
-  let idx = 0;
-  (function type() {
-    if (idx < codeText.length) {
-      codeBlock.textContent += codeText.charAt(idx);
-      idx++;
-      setTimeout(type, 20);
-    }
-  })();
 
   runHeroAnimations();
-
-  document.getElementById('scrollCue').addEventListener('click', () => {
-    const target = document.getElementById('about');
-    if (target) {
-      target.scrollIntoView({ behavior: 'smooth' });
-    }
-  });
+  cycleSnippets();
 
   window.addEventListener('scroll', () => {
     navbar.classList.toggle('scrolled', window.scrollY > 10);
@@ -52,93 +32,74 @@ const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").mat
 
 function runHeroAnimations() {
   if (prefersReduced) {
-    gsap.set(["#hero", "[data-hero-el]"], { opacity: 1, y: 0, clearProps: "all" });
+    gsap.set([".hero-left", ".portrait-wrapper", ".stat", ".feature-block"], { opacity: 1, y: 0, clearProps: "all" });
     return;
   }
 
-  gsap.registerPlugin(ScrollTrigger);
   const tl = gsap.timeline({ defaults: { ease: "power3.out" } });
+  tl.from(".hero-left", { x: -24, opacity: 0, duration: 0.8 })
+    .from(".portrait-wrapper", { scale: 0.98, opacity: 0, duration: 0.8 }, "-=0.4")
+    .from(".stat", { y: -20, opacity: 0, stagger: 0.08, duration: 0.5 }, "-=0.4")
+    .from("[data-cta]", { y: 10, opacity: 0, duration: 0.5 }, "-=0.3")
+    .from(".feature-block", { y: 20, opacity: 0, stagger: 0.08, duration: 0.6 }, "-=0.2");
 
-  tl.to("#code-intro", { opacity: 1, duration: 0.2 })
-    .to("#code-intro", { opacity: 0, filter: "blur(10px)", pointerEvents: "none", duration: 0.6, delay: 1.3 });
-
-  tl.fromTo("#heroCard", { opacity: 0, y: 16, filter: "blur(8px)" },
-                     { opacity: 1, y: 0, filter: "blur(0px)", duration: 0.8 }, "<0.1");
-
-    tl.from("[data-hero-h1]", { opacity: 0, y: 10, duration: 0.6 }, "-=0.2")
-      .from("[data-hero-sub]", { opacity: 0, y: 10, duration: 0.5 }, "-=0.2")
-      .from("[data-chip]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
-      .from("[data-avatar]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
-      .from("[data-bio]", { opacity: 0, y: 10, duration: 0.4 }, "-=0.2")
-      .from("[data-metric]", { opacity: 0, y: 10, stagger: 0.08, duration: 0.4 }, "-=0.2")
-      .call(animateMetrics, null, "-=0.1")
-      .from("[data-badge]", { opacity: 0, y: 8, stagger: 0.08, duration: 0.3 }, "-=0.2")
-      .from("[data-skill]", { opacity: 0, y: 10, stagger: 0.08, duration: 0.4 }, "-=0.2")
-      .from("[data-cta]", { opacity: 0, y: 8, stagger: 0.08, duration: 0.35 }, "-=0.2")
-      .to("#scrollCue", { opacity: 1, duration: 0.3 }, "-=0.1");
-
-
-  const card = document.querySelector("#heroCard");
-  if (window.matchMedia("(pointer: fine)").matches && card) {
-    card.addEventListener("mousemove", (e) => {
-      const r = card.getBoundingClientRect();
+  const imgHolder = document.querySelector('[data-parallax]');
+  if (window.matchMedia('(pointer: fine)').matches && imgHolder) {
+    imgHolder.addEventListener('mousemove', (e) => {
+      const r = imgHolder.getBoundingClientRect();
       const x = (e.clientX - (r.left + r.width / 2)) / r.width;
       const y = (e.clientY - (r.top + r.height / 2)) / r.height;
-      gsap.to("#heroBG", { x: x * 8, y: y * 6, duration: 0.3, overwrite: true });
-      gsap.to("[data-hero-h1]", { x: x * 3, y: y * 2, duration: 0.3, overwrite: true });
+      gsap.to(imgHolder, { x: x * 6, y: y * 6, duration: 0.3, overwrite: true });
+    });
+    imgHolder.addEventListener('mouseleave', () => {
+      gsap.to(imgHolder, { x: 0, y: 0, duration: 0.3 });
     });
   }
 
-  const avatar = document.querySelector('[data-avatar]');
-  if (window.matchMedia('(pointer: fine)').matches && avatar) {
-    avatar.addEventListener('mousemove', (e) => {
-      const r = avatar.getBoundingClientRect();
-      const x = (e.clientX - (r.left + r.width / 2)) / r.width;
-      const y = (e.clientY - (r.top + r.height / 2)) / r.height;
-      gsap.to(avatar, { rotationY: x * 10, rotationX: -y * 10, duration: 0.3, transformPerspective: 500, overwrite: true });
-    });
-    avatar.addEventListener('mouseleave', () => {
-      gsap.to(avatar, { rotationY: 0, rotationX: 0, duration: 0.3 });
-    });
-  }
-
-  const btns = gsap.utils.toArray("[data-cta]");
-  btns.forEach((b) => {
-    b.addEventListener("mouseenter", () =>
-      gsap.to(b, { scale: 1.02, boxShadow: "0 10px 24px rgba(0,0,0,.18)", duration: 0.18, ease: "power2.out" })
-    );
-    b.addEventListener("mouseleave", () =>
-      gsap.to(b, { scale: 1.0, boxShadow: "0 4px 12px rgba(0,0,0,.12)", duration: 0.18, ease: "power2.out" })
-    );
-  });
-}
-
-function animateMetrics() {
-  document.querySelectorAll('[data-count]').forEach((el) => {
-    const end = parseInt(el.getAttribute('data-count'), 10);
-    const suffix = el.getAttribute('data-suffix') || '';
-    gsap.fromTo(el, { innerText: 0 }, {
-      innerText: end,
-      duration: 1.2,
-      ease: 'power1.out',
-      snap: { innerText: 1 },
-      onUpdate: function () {
-        el.textContent = Math.round(el.innerText) + suffix;
-      }
-    });
-  });
-}
-
-// Reveal the clean strip for "About Me" section on scroll
-window.addEventListener('scroll', function() {
-  const aboutSection = document.getElementById('about');
-  if (aboutSection) {
-    const rect = aboutSection.getBoundingClientRect();
-    if (rect.top < window.innerHeight * 0.8) {
-      aboutSection.classList.add('scrolled');
+  gsap.to('.hero-transition path', {
+    attr: { d: 'M0,0 C480,40 960,40 1440,0 L1440,80 L0,80 Z' },
+    scrollTrigger: {
+      trigger: '.hero-transition',
+      start: 'top bottom',
+      scrub: true
     }
+  });
+
+  const btns = gsap.utils.toArray('[data-cta]');
+  btns.forEach((b) => {
+    b.addEventListener('mouseenter', () =>
+      gsap.to(b, { scale: 1.02, duration: 0.18, ease: 'power2.out' })
+    );
+    b.addEventListener('mouseleave', () =>
+      gsap.to(b, { scale: 1.0, duration: 0.18, ease: 'power2.out' })
+    );
+  });
+}
+
+function cycleSnippets() {
+  const snippets = [
+    '<Hero name="Nour" />',
+    '<Button primary>Contact</Button>'
+  ];
+  let i = 0;
+  function type() {
+    const el = document.getElementById('code-snippet');
+    if (!el) return;
+    const text = snippets[i];
+    el.textContent = '';
+    let c = 0;
+    (function tick() {
+      if (c < text.length) {
+        el.textContent += text.charAt(c++);
+        setTimeout(tick, 80);
+      } else {
+        i = (i + 1) % snippets.length;
+        setTimeout(type, 7000);
+      }
+    })();
   }
-});
+  type();
+}
 
 window.onload = function() {
   animateSkillBars();

--- a/index.html
+++ b/index.html
@@ -7,130 +7,74 @@
   <title>Welcome to Nour's Website</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&family=Playfair+Display:ital,wght@1,600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="Resume.css">
 </head>
 
 <body>
-  <div id="code-intro" class="code-intro"><pre id="code-block"></pre></div>
   <nav class="navbar">
     <a href="#hero" class="nav-link active">Home</a>
-    <a href="#about" class="nav-link">About</a>
     <a href="#card" class="nav-link">Contact</a>
     <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
   </nav>
-  <div class="welcome-section" id="hero">
-    <div class="background-animation" id="heroBG">
-      <div class="floating-shapes">
-        <div class="shape shape-1"></div>
-        <div class="shape shape-2"></div>
-        <div class="shape shape-3"></div>
-        <div class="shape shape-4"></div>
-        <div class="shape shape-5"></div>
-      </div>
-    </div>
 
-    <div class="header-content">
-      <div class="profile-intro glass-panel" id="heroCard" role="region" aria-label="Intro">
-        <img src="images/IMG_8098.jpeg" alt="Noureldeen Fahmy" class="hero-avatar" data-avatar>
-        <h1 class="main-title" data-hero-h1>
-          <span class="greeting">Hello, I'm</span>
-          <span class="name" id="hero-name">Noureldeen Fahmy</span>
-        </h1>
-        <p class="hero-tagline" data-hero-sub>Full-stack developer &amp; data scientist</p>
-        <div class="company-tag">
-          <a href="https://www.storelx.com" target="_blank" data-chip>Storelx</a>
-        </div>
-        <p class="hero-bio" data-bio>I build polished, scalable web platforms and data products that power real businesses.</p>
-        <div class="hero-metrics">
-          <div class="metric" data-metric>
-            <span class="metric-number" data-count="100" data-suffix="+">0</span>
-            <span class="metric-label">Active Users</span>
+  <section class="hero" id="hero">
+    <div class="hero-canvas">
+      <div class="hero-grid">
+        <div class="hero-left">
+          <p class="hero-eyebrow">HEY, I'M NOUR,</p>
+          <h1 class="hero-heading">
+            <span class="hero-name" data-tooltip="// Hi recruiter—welcome!">Noureldeen</span><br>
+            <span class="hero-role">Developer</span>
+          </h1>
+          <p class="hero-subhead">I build polished, scalable web platforms and data products that power real businesses.</p>
+          <div class="hero-about">
+            <p>I’m a full-stack developer and data scientist who ships production-ready software.</p>
+            <p>I’ve led builds for a peer-to-peer marketplace, analytics dashboards, and ML-assisted features—always with performance, accessibility, and testing front-of-mind.</p>
+            <p>Tooling I love: <strong>React 18</strong>, <strong>Node.js/Express</strong>, <strong>PostgreSQL</strong>, <strong>Prisma</strong>, <strong>AWS</strong>, <strong>Docker</strong>, <strong>CI/CD</strong>.</p>
           </div>
-          <div class="metric" data-metric>
-            <span class="metric-number" data-count="40" data-suffix="%">0</span>
-            <span class="metric-label">Faster API</span>
-          </div>
-          <div class="metric" data-metric>
-            <span class="metric-number" data-count="85" data-suffix="%">0</span>
-            <span class="metric-label">ML Accuracy</span>
+          <a href="#card" class="hero-cta" data-cta>Contact Me <span class="cta-arrow">→</span></a>
+          <div class="hero-links">
+            <a href="Resume.pdf" class="hero-link">View Résumé</a>
+            <a href="#projects" class="hero-link">See Projects</a>
           </div>
         </div>
-        <div class="trusted-badges">
-          <img src="images/github.png" alt="GitHub" data-badge>
-          <img src="images/icons8-linkedin-96.png" alt="LinkedIn" data-badge>
-        </div>
-        <div class="skill-tags">
-          <span class="skill-tag" data-skill>React</span>
-          <span class="skill-tag" data-skill>Node.js</span>
-          <span class="skill-tag" data-skill>Python</span>
-          <span class="skill-tag" data-skill>AWS</span>
-        </div>
-        <div class="header-actions">
-          <a href="#card" class="cta-button primary" data-cta aria-label="Contact me">
-            <span class="button-icon">📧</span>
-            <span class="button-text">Contact Me</span>
-          </a>
-          <a href="#about" class="cta-button secondary" data-cta aria-label="Learn more about me">
-            <span class="button-icon">👤</span>
-            <span class="button-text">About Me</span>
-          </a>
+        <div class="hero-right">
+          <div class="portrait-wrapper" data-parallax>
+            <div class="shield"></div>
+            <img src="images/IMG_8098.jpeg" alt="Noureldeen Fahmy" class="portrait">
+            <div class="code-panel"><pre id="code-snippet"></pre></div>
+          </div>
+          <div class="hero-stats">
+            <div class="stat"><span class="stat-number">100+</span><span class="stat-label">Active Users</span></div>
+            <div class="stat"><span class="stat-number">5+</span><span class="stat-label">Projects</span></div>
+            <div class="stat"><span class="stat-number">3+</span><span class="stat-label">Years</span></div>
+            <div class="stat"><span class="stat-number">95%</span><span class="stat-label">Sprint Completion</span></div>
+          </div>
         </div>
       </div>
-
-      <div class="scroll-indicator">
-        <div class="down-arrow" id="scrollCue"></div>
+      <div class="feature-row">
+        <div class="feature-block">
+          <h3>USER-CENTERED DEVELOPMENT</h3>
+          <p>Crafting intuitive, accessible interfaces.</p>
+        </div>
+        <div class="feature-block">
+          <h3>SCALABLE SYSTEMS</h3>
+          <p>Architecture that grows with your product.</p>
+        </div>
+        <div class="feature-block">
+          <h3>DATA-DRIVEN</h3>
+          <p>Using data to inform every decision.</p>
+        </div>
+        <div class="feature-block">
+          <h3>AGILE MINDSET</h3>
+          <p>Iterating fast to deliver results.</p>
+        </div>
       </div>
-    </div>
-  </div>
-
-  <!-- About Me Section -->
-  <section class="about-section fade-section" id="about">
-    <div class="content-container">
-      <h2>About Me</h2>
-      <div class="about-flex">
-        <div class="about-left">
-          <div class="about-intro">
-            <p>
-              I'm <strong>Noureldeen Fahmy</strong>, a Computer Science Honours student at Memorial University of Newfoundland, graduating in 2025. I specialize in building scalable full-stack web platforms and data-driven applications.
-            </p>
-            <p>
-              With a solid background in full-stack development and data science, I've led agile teams, developed intelligent data pipelines, and built real-world products used by thousands.
-            </p>
-            <p>
-              My mission is simple: combine great engineering with actionable data to solve real problems. I love working in collaborative environments where I can continuously grow and deliver impact.
-            </p>
-          </div>
-  
-          <div class="about-highlights">
-            <div class="highlight-item">🌟 Built & led a P2P storage marketplace (Storelx)</div>
-            <div class="highlight-item">📉 Reduced API response time by 40%</div>
-            <div class="highlight-item">📊 85% accuracy in ML forecasting</div>
-            <div class="highlight-item">👨‍💻 Led team of 3+ devs in agile sprints</div>
-          </div>
-        </div>
-  
-        <!-- Right: Stats -->
-        <div class="about-right">
-          <div class="stats-grid">
-            <div class="stat-item">
-              <div class="stat-number">100+</div>
-              <div class="stat-label">Active Users</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">5+</div>
-              <div class="stat-label">Projects Completed</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">3+</div>
-              <div class="stat-label">Years of Experience</div>
-            </div>
-            <div class="stat-item">
-              <div class="stat-number">95%</div>
-              <div class="stat-label">Sprint Completion</div>
-            </div>
-          </div>
-        </div>
+      <div class="hero-transition">
+        <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
+          <path d="M0,0 C480,80 960,0 1440,80 L1440,80 L0,80 Z" fill="currentColor"></path>
+        </svg>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Rebuild hero into editorial poster-style canvas merging About content, portrait shield, vertical stats, and feature row
- Add tooltip and code-snippet easter egg with GSAP-driven animations and parallax
- Refresh theme tokens and remove legacy hero styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b50df3883329b19e3cb5cfafbc7