### PR TITLE
Refine hero layout with shield and overlap

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -118,14 +118,17 @@ body {
   display:grid;
   grid-template-columns:repeat(12,1fr);
   column-gap:60px;
-  align-items:center;
+  align-items:start;
   margin-bottom:60px;
+  position:relative;
 }
 
 .hero-left {
-  grid-column:1 / span 7;
+  grid-column:1 / span 6;
   position:relative;
-  z-index:2;
+  z-index:30;
+  margin-top:-24px;
+  max-width:48ch;
 }
 
 .hero-eyebrow {
@@ -134,27 +137,20 @@ body {
   font-size:0.875rem;
   color:var(--text-muted);
   margin-bottom:20px;
+  text-shadow:0 2px 8px rgba(0,0,0,0.35);
 }
 
 .hero-heading {
   margin:0 0 24px;
-  line-height:1.1;
-}
-
-
-.hero-role {
-  display:inline-block;
+  line-height:1.05;
+  text-shadow:0 2px 8px rgba(0,0,0,0.35);
   font-size:56px;
-  font-weight:700;
-  line-height:1.1;
-  position:relative;
-  z-index:2;
-  transform:translateX(40px);
 }
 
 .role-main {
   font-family:'Poppins', sans-serif;
   font-weight:700;
+  display:block;
 }
 
 .role-sub {
@@ -162,20 +158,23 @@ body {
   font-style:italic;
   font-weight:600;
   color:var(--text-secondary);
+  display:block;
 }
 
 .hero-description {
-  font-size:20px;
-  line-height:1.6;
-  max-width:480px;
+  font-size:18px;
+  line-height:1.68;
+  max-width:68ch;
   margin-bottom:16px;
   color:var(--text-secondary);
+  text-shadow:0 2px 8px rgba(0,0,0,0.30);
 }
 
 .hero-tools {
   font-size:16px;
   color:var(--text-muted);
   margin-bottom:32px;
+  text-shadow:0 2px 8px rgba(0,0,0,0.35);
 }
 
 .hero-cta {
@@ -201,44 +200,55 @@ body {
 .hero-cta:hover .cta-arrow { transform:translateX(3px); }
 
 
-.hero-right {
-  grid-column:8 / span 5;
-  display:flex;
-  align-items:center;
-  gap:60px;
+.hero-photo {
+  grid-column:7 / span 4;
   position:relative;
 }
 
 .portrait-wrapper {
   position:relative;
-  width:420px;
-  height:560px;
+  z-index:20;
+  width:460px;
+  height:540px;
   max-width:100%;
+  transform:translateX(-56px);
+  border-radius:24px;
+  overflow:hidden;
+  border:1px solid rgba(255,255,255,0.1);
+  box-shadow:0 20px 60px rgba(0,0,0,0.45);
 }
 
-.portrait-wrapper .shield {
+.photo-shield {
   position:absolute;
-  inset:-60px;
-  border-radius:60px;
-  background:radial-gradient(circle at 30% 30%, rgba(47,110,234,0.4), rgba(245,158,11,0.35));
-  filter:blur(60px);
-  box-shadow:0 40px 60px rgba(0,0,0,0.5);
-  z-index:-1;
-  animation:shieldShift 8s ease-in-out infinite alternate;
+  top:-32px;
+  left:-32px;
+  width:520px;
+  height:620px;
+  border-radius:32px;
+  background:linear-gradient(to bottom,#12161F,#0F1115);
+  border:1px solid rgba(255,255,255,0.06);
+  box-shadow:0 30px 80px rgba(0,0,0,0.55);
+  z-index:10;
+  overflow:hidden;
 }
 
-@keyframes shieldShift {
-  from { transform:translateX(-10px); }
-  to { transform:translateX(10px); }
+.shield-highlight {
+  position:absolute;
+  top:-40px;
+  left:-32px;
+  width:300px;
+  height:300px;
+  border-radius:50%;
+  background:radial-gradient(circle at center,rgba(47,110,234,0.16),rgba(47,110,234,0) 60%);
+  filter:blur(32px);
 }
 
 .portrait {
   width:100%;
   height:100%;
   object-fit:cover;
-  border-radius:20px;
+  border-radius:24px;
   display:block;
-  box-shadow:0 12px 32px rgba(0,0,0,0.6);
 }
 
 .code-panel {
@@ -257,15 +267,20 @@ body {
 }
 
 .hero-stats {
+  grid-column:11 / span 2;
   display:flex;
   flex-direction:column;
   gap:32px;
-  padding-left:40px;
+  padding-left:60px;
   border-left:1px solid rgba(255,255,255,0.12);
 }
 
 [data-theme='light'] .hero-stats {
   border-left:1px solid rgba(0,0,0,0.12);
+}
+
+[data-theme='light'] .portrait-wrapper {
+  border:1px solid rgba(0,0,0,0.1);
 }
 
 .stat-number {
@@ -325,18 +340,27 @@ body {
 
 .feature-block:hover::after { width:60%; }
 
+@media (max-width:1279px){
+  .hero-left{ max-width:42ch; }
+  .portrait-wrapper{ width:440px; height:520px; transform:translateX(-40px); }
+  .photo-shield{ width:500px; height:600px; }
+}
+
 @media (max-width:1024px){
-  .hero-right{ flex-direction:column; gap:40px; }
-  .portrait-wrapper{ width:320px; height:420px; }
-  .hero-stats{ padding-left:0; border-left:none; display:grid; grid-template-columns:repeat(2,1fr); gap:20px; width:100%; }
+  .hero-grid{ grid-template-columns:1fr; row-gap:40px; }
+  .hero-left{ grid-column:1/-1; text-align:center; margin-top:0; }
+  .hero-photo{ grid-column:1/-1; }
+  .portrait-wrapper{ width:100%; height:420px; transform:none; }
+  .photo-shield{ top:-24px; left:0; width:100%; height:100%; }
+  .hero-stats{ grid-column:1/-1; padding-left:0; border-left:none; display:grid; grid-template-columns:repeat(2,1fr); gap:20px; width:100%; }
   .stat{ text-align:center; }
 }
 
+@media (max-width:640px){
+  .hero-heading{ font-size:40px; }
+}
+
 @media (max-width:768px){
-  .hero-grid{ grid-template-columns:1fr; row-gap:40px; }
-  .hero-left{ grid-column:1/-1; text-align:center; }
-  .hero-right{ grid-column:1/-1; }
-  .portrait-wrapper{ width:100%; height:auto; }
   .feature-row{ grid-template-columns:repeat(2,1fr); }
   .feature-block{ border-top:1px solid var(--border-hairline); }
   .feature-block:nth-child(odd){ border-left:none; }

--- a/Resume.js
+++ b/Resume.js
@@ -43,29 +43,39 @@ function runHeroAnimations() {
     .from("[data-cta]", { y: 10, opacity: 0, duration: 0.5 }, "-=0.3")
     .from(".feature-block", { y: 20, opacity: 0, stagger: 0.08, duration: 0.6 }, "-=0.2");
 
-  const imgHolder = document.querySelector('[data-parallax]');
-  if (window.matchMedia('(pointer: fine)').matches && imgHolder) {
-    imgHolder.addEventListener('mousemove', (e) => {
-      const r = imgHolder.getBoundingClientRect();
-      const x = (e.clientX - (r.left + r.width / 2)) / r.width;
-      const y = (e.clientY - (r.top + r.height / 2)) / r.height;
-      gsap.to(imgHolder, { x: x * 6, y: y * 6, duration: 0.3, overwrite: true });
-    });
-    imgHolder.addEventListener('mouseleave', () => {
-      gsap.to(imgHolder, { x: 0, y: 0, duration: 0.3 });
-    });
-  }
+  const wrap = document.getElementById('photoWrap');
+  if (window.matchMedia('(pointer: fine)').matches && wrap) {
+      wrap.addEventListener('mousemove', e => {
+        const r = wrap.getBoundingClientRect();
+        const x = (e.clientX - (r.left + r.width / 2)) / r.width;
+        const y = (e.clientY - (r.top + r.height / 2)) / r.height;
+        wrap.style.transform = `translateX(-56px) translate(${x * 6}px, ${y * 4}px)`;
+      });
+      wrap.addEventListener('mouseleave', () => {
+        wrap.style.transform = 'translateX(-56px)';
+      });
+    }
 
   const btns = gsap.utils.toArray('[data-cta]');
-  btns.forEach((b) => {
-    b.addEventListener('mouseenter', () =>
-      gsap.to(b, { scale: 1.02, duration: 0.18, ease: 'power2.out' })
-    );
-    b.addEventListener('mouseleave', () =>
-      gsap.to(b, { scale: 1.0, duration: 0.18, ease: 'power2.out' })
-    );
-  });
-}
+    btns.forEach((b) => {
+      b.addEventListener('mouseenter', () =>
+        gsap.to(b, { scale: 1.02, duration: 0.18, ease: 'power2.out' })
+      );
+      b.addEventListener('mouseleave', () =>
+        gsap.to(b, { scale: 1.0, duration: 0.18, ease: 'power2.out' })
+      );
+    });
+
+    const contact = document.querySelector('a[href="#card"]');
+    if (contact) {
+      contact.addEventListener('mouseover', () => {
+        const link = document.createElement('link');
+        link.rel = 'prefetch';
+        link.href = '#card';
+        document.head.appendChild(link);
+      }, { once: true });
+    }
+  }
 
 function cycleSnippets() {
   const snippets = [

--- a/index.html
+++ b/index.html
@@ -20,30 +20,33 @@
 
   <section class="hero" id="hero">
     <div class="hero-canvas">
-      <div class="hero-grid">
-        <div class="hero-left">
-          <p class="hero-eyebrow">HEY, I'M NOURELDEEN FAHMY</p>
-          <h1 class="hero-heading">
-            <span class="hero-role"><span class="role-main">Software Developer</span> <span class="role-sub">&amp; Data Scientist</span></span>
-          </h1>
-          <p class="hero-description">I build polished, scalable web platforms and data products that power real businesses.</p>
-          <p class="hero-tools">React 18 · Node.js/Express · PostgreSQL · AWS</p>
-          <a href="#card" class="hero-cta" data-cta>Contact Me <span class="cta-arrow">→</span></a>
-        </div>
-        <div class="hero-right">
-          <div class="portrait-wrapper" data-parallax>
-            <div class="shield"></div>
-            <img src="images/IMG_8098.jpeg" alt="Noureldeen Fahmy" class="portrait">
-            <div class="code-panel"><pre id="code-snippet"></pre></div>
+        <div class="hero-grid">
+          <div class="hero-left">
+            <p class="hero-eyebrow">HEY, I'M NOURELDEEN FAHMY</p>
+            <h1 class="hero-heading">
+              <span class="role-main">Software Developer</span>
+              <span class="role-sub">&amp; Data Scientist</span>
+            </h1>
+            <p class="hero-description">I’m a passionate Software Developer &amp; Data Scientist dedicated to building polished, scalable web platforms and data products that deliver real business value. With over 3 years of experience, I’ve led the development of high-performance applications—from peer-to-peer marketplaces to predictive analytics tools—leveraging technologies like React, Node.js, PostgreSQL, and AWS. My work blends user-centered design with scalable architectures and data-driven decision-making, ensuring products are not only functional but also impactful. Whether architecting microservices, optimizing databases, or crafting intuitive interfaces, I thrive on turning complex challenges into elegant, efficient solutions.</p>
+            <p class="hero-tools">React 18 · Node.js/Express · PostgreSQL · AWS</p>
+            <a href="#card" class="hero-cta" data-cta>Contact Me <span class="cta-arrow">→</span></a>
           </div>
-          <div class="hero-stats">
+          <div class="hero-photo">
+            <div class="photo-shield" aria-hidden="true">
+              <div class="shield-highlight"></div>
+            </div>
+            <div id="photoWrap" class="portrait-wrapper">
+              <img src="images/IMG_8098.jpeg" alt="Noureldeen Fahmy" class="portrait" loading="lazy">
+              <div class="code-panel"><pre id="code-snippet"></pre></div>
+            </div>
+          </div>
+          <aside class="hero-stats">
             <div class="stat"><span class="stat-number">100+</span><span class="stat-label">Active Users</span></div>
             <div class="stat"><span class="stat-number">5+</span><span class="stat-label">Projects</span></div>
             <div class="stat"><span class="stat-number">3+</span><span class="stat-label">Years</span></div>
             <div class="stat"><span class="stat-number">95%</span><span class="stat-label">Sprint Completion</span></div>
-          </div>
+          </aside>
         </div>
-      </div>
       <div class="feature-row">
         <div class="feature-block">
           <h3>USER-CENTERED DEVELOPMENT</h3>


### PR DESCRIPTION
## Summary
- Replace hero body copy with an extended About paragraph and elevate the text block above the photo for a floating effect
- Add a dark editorial shield and radial highlight behind the portrait and tweak photo sizing/shift for overlap
- Adjust parallax baseline, lazy-load the hero image and prefetch the contact link on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f22ebd8dc83329f5b7370ac9fb692