### PR TITLE
Add project showcase section

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -637,53 +637,21 @@ pre code {
   background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
   opacity: 0.3;
 }
-.projects-container { max-width: 1200px; margin: 0 auto; padding: 0 20px; position: relative; z-index: 1; }
-.projects-header { text-align: center; margin-bottom: 60px; color: var(--text-primary); }
-.projects-header h2 { font-size: 3rem; font-weight: 700; margin-bottom: 15px; text-shadow: 2px 2px 4px rgba(0,0,0,0.3); }
-.projects-header p  { font-size: 1.2rem; opacity: 0.9; font-weight: 300; color: var(--text-secondary); }
+.showcase-header { text-align: center; margin-bottom: 60px; }
+.showcase-header h2 { font-size: 3rem; font-weight: 700; }
+.showcase-header h2 span { color: var(--accent-solid); }
+.showcase-header p { font-size: 1.1rem; color: var(--text-secondary); margin-top: 10px; }
 
-.projects-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 30px; margin-top: 40px; }
-.project-card {
-  background: var(--bg-elevated);
-  border-radius: 20px; padding: 30px;
-  box-shadow: 0 20px 40px rgba(0,0,0,0.1);
-  transition: all 0.3s ease; position: relative; overflow: hidden;
-  border: 1px solid var(--border-hairline);
-}
-.project-card::before {
-  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px;
-  background: var(--accent-color); border-radius: 20px 20px 0 0;
-}
-.project-card:hover { transform: translateY(-10px); box-shadow: 0 30px 60px rgba(0,0,0,0.2); }
-
-.project-card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; }
-.project-card-header h3 { font-size: 1.5rem; color: var(--text-primary); margin: 0; font-weight: 600; }
-.project-date { background: linear-gradient(135deg, var(--accent-solid), var(--accent-solid)); color: var(--text-onAccent);
-  padding: 5px 15px; border-radius: 20px; font-size: 0.9rem; font-weight: 500; }
-.project-location { color: var(--text-secondary); font-size: 0.95rem; margin-bottom: 15px; font-weight: 500; }
-
-.project-description { margin-bottom: 20px; }
-.project-description p { color: var(--text-secondary); line-height: 1.6; font-size: 1rem; }
-.project-details { margin-bottom: 20px; padding-left: 20px; }
-.project-details li { color: var(--text-secondary); line-height: 1.5; font-size: 0.95rem; list-style: disc; }
-
-.project-tech { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 25px; }
-.tech-tag { background: var(--accent-solid); color: var(--text-onAccent); padding: 5px 12px; border-radius: 15px; font-size: 0.8rem; font-weight: 500; }
-
-.project-actions { display: flex; gap: 15px; align-items: center; }
-.project-link {
-  background: var(--accent-solid); color: var(--text-onAccent);
-  padding: 12px 20px; border-radius: 25px; font-weight: 500;
-  display: flex; align-items: center; gap: 8px; transition: transform 0.3s ease;
-}
-.project-link:hover { transform: translateY(-2px); background: var(--accent-hover); }
+.showcase-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 40px; }
+.showcase-card img { width: 100%; border-radius: 12px; }
+.showcase-title { margin-top: 20px; font-size: 1.5rem; }
+.showcase-tags { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 8px; }
+.showcase-tag { background: var(--chip-bg); border: 1px solid var(--chip-border); color: var(--chip-text); padding: 4px 10px; border-radius: 20px; font-size: 0.75rem; }
+.showcase-description { margin-top: 12px; color: var(--text-secondary); line-height: 1.5; font-size: 0.95rem; }
 
 @media (max-width: 768px) {
-  .projects-grid { grid-template-columns: 1fr; gap: 20px; }
-  .project-card { padding: 20px; }
-  .projects-header h2 { font-size: 2.5rem; }
-  .project-actions { flex-direction: column; gap: 10px; }
-  .project-link { width: 100%; justify-content: center; }
+  .showcase-grid { grid-template-columns: 1fr; gap: 20px; }
+  .showcase-header h2 { font-size: 2.5rem; }
 }
 
 /* ========================================================================== */

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 <body>
   <nav class="navbar">
     <a href="#hero" class="nav-link active">Home</a>
+    <a href="#projects" class="nav-link">Projects</a>
     <a href="#card" class="nav-link">Contact</a>
     <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
   </nav>
@@ -80,9 +81,55 @@
         </div>
       </div>
     </div>
-  </section>
+    </section>
 
-  <!-- Education Section -->
+    <section class="projects-section fade-section" id="projects">
+      <div class="showcase-header">
+        <h2>Project <span>Showcase</span></h2>
+        <p>In today's crowded digital world, it's not just about being louder — it's about being meaningful.</p>
+      </div>
+      <div class="showcase-grid">
+        <article class="showcase-card">
+          <img src="https://via.placeholder.com/600x400" alt="FlexPay project screenshot">
+          <h3 class="showcase-title">FlexPay – AI Finance</h3>
+          <div class="showcase-tags">
+            <span class="showcase-tag">UI/UX Design</span>
+            <span class="showcase-tag">Product Design</span>
+            <span class="showcase-tag">Dashboard</span>
+          </div>
+          <p class="showcase-description">A finance management platform powered by AI. Redesigned their mobile experience to simplify budgeting, credit scoring, and smarter financial decision-making.</p>
+        </article>
+        <article class="showcase-card">
+          <img src="https://via.placeholder.com/600x400" alt="Cowboy project screenshot">
+          <h3 class="showcase-title">Cowboy – Modern Timeless Bike</h3>
+          <div class="showcase-tags">
+            <span class="showcase-tag">UI/UX Design</span>
+            <span class="showcase-tag">Product Design</span>
+          </div>
+          <p class="showcase-description">Redesigned the digital experience for Cowboy, a premium e-bike brand. Focused on creating a modern, minimal UI across mobile and web.</p>
+        </article>
+        <article class="showcase-card">
+          <img src="https://via.placeholder.com/600x400" alt="Credivance project screenshot">
+          <h3 class="showcase-title">Credivance – AI Credit Manager</h3>
+          <div class="showcase-tags">
+            <span class="showcase-tag">Brand Development</span>
+            <span class="showcase-tag">Product Design</span>
+          </div>
+          <p class="showcase-description">Built a cohesive brand and product design system for an AI-driven credit management platform covering both web and mobile.</p>
+        </article>
+        <article class="showcase-card">
+          <img src="https://via.placeholder.com/600x400" alt="Archivr project screenshot">
+          <h3 class="showcase-title">Archivr. – AI Digital Product</h3>
+          <div class="showcase-tags">
+            <span class="showcase-tag">Brand Development</span>
+            <span class="showcase-tag">Visual Identity</span>
+          </div>
+          <p class="showcase-description">An AI-powered archival tool. Developed the brand system and responsive product design across platforms.</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Education Section -->
   <div class="education-section fade-section" id="education">
     <div class="content-container">
       <h2>Education</h2>


### PR DESCRIPTION
## Summary
- Add Project Showcase section with placeholder images and descriptive tags
- Style showcase grid and cards for responsive layout
- Update navigation with Projects link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9622e0e08332ac1562d99f56e32f