### PR TITLE
Refactor projects into reusable React component

### DIFF
--- a/Resume.css
+++ b/Resume.css
@@ -637,54 +637,49 @@ pre code {
   background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
   opacity: 0.3;
 }
+/* Projects section */
 .projects-container { max-width: 1200px; margin: 0 auto; padding: 0 20px; position: relative; z-index: 1; }
-.projects-header { text-align: center; margin-bottom: 60px; color: var(--text-primary); }
+.projects-header { margin-bottom: 60px; color: var(--text-primary); }
+.projects-header-row { display:flex; justify-content: space-between; align-items:center; }
 .projects-header h2 { font-size: 3rem; font-weight: 700; margin-bottom: 15px; text-shadow: 2px 2px 4px rgba(0,0,0,0.3); }
-.projects-header p  { font-size: 1.2rem; opacity: 0.9; font-weight: 300; color: var(--text-secondary); }
+.projects-header p  { font-size: 1.2rem; opacity: 0.9; font-weight: 300; color: var(--text-secondary); text-align:center; }
+.see-more { color: var(--accent-solid); font-size:1rem; }
+.see-more:hover { text-decoration: underline; }
 
-.projects-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 30px; margin-top: 40px; }
-.project-card {
-  background: var(--bg-elevated);
-  border-radius: 20px; padding: 30px;
-  box-shadow: 0 20px 40px rgba(0,0,0,0.1);
-  transition: all 0.3s ease; position: relative; overflow: hidden;
-  border: 1px solid var(--border-hairline);
-}
-.project-card::before {
-  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px;
-  background: var(--accent-color); border-radius: 20px 20px 0 0;
-}
-.project-card:hover { transform: translateY(-10px); box-shadow: 0 30px 60px rgba(0,0,0,0.2); }
-
-.project-card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; }
-.project-card-header h3 { font-size: 1.5rem; color: var(--text-primary); margin: 0; font-weight: 600; }
-.project-date { background: linear-gradient(135deg, var(--accent-solid), var(--accent-solid)); color: var(--text-onAccent);
-  padding: 5px 15px; border-radius: 20px; font-size: 0.9rem; font-weight: 500; }
-.project-location { color: var(--text-secondary); font-size: 0.95rem; margin-bottom: 15px; font-weight: 500; }
-
-.project-description { margin-bottom: 20px; }
-.project-description p { color: var(--text-secondary); line-height: 1.6; font-size: 1rem; }
-.project-details { margin-bottom: 20px; padding-left: 20px; }
-.project-details li { color: var(--text-secondary); line-height: 1.5; font-size: 0.95rem; list-style: disc; }
-
-.project-tech { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 25px; }
-.tech-tag { background: var(--accent-solid); color: var(--text-onAccent); padding: 5px 12px; border-radius: 15px; font-size: 0.8rem; font-weight: 500; }
-
-.project-actions { display: flex; gap: 15px; align-items: center; }
-.project-link {
-  background: var(--accent-solid); color: var(--text-onAccent);
-  padding: 12px 20px; border-radius: 25px; font-weight: 500;
-  display: flex; align-items: center; gap: 8px; transition: transform 0.3s ease;
-}
-.project-link:hover { transform: translateY(-2px); background: var(--accent-hover); }
 
 @media (max-width: 768px) {
-  .projects-grid { grid-template-columns: 1fr; gap: 20px; }
-  .project-card { padding: 20px; }
   .projects-header h2 { font-size: 2.5rem; }
-  .project-actions { flex-direction: column; gap: 10px; }
-  .project-link { width: 100%; justify-content: center; }
 }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal[hidden] { display: none; }
+.modal-content {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  padding: 30px;
+  border-radius: 15px;
+  text-align: center;
+  max-width: 90%;
+  width: 400px;
+  border: 1px solid var(--border-hairline);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.2);
+}
+.modal-close {
+  margin-top: 20px;
+  background: var(--accent-solid);
+  color: var(--text-onAccent);
+  padding: 10px 20px;
+  border-radius: 20px;
+}
+.modal-close:hover { background: var(--accent-hover); }
 
 /* ========================================================================== */
 /* 09) SKILLS (MODERN)                                                        */

--- a/Resume.js
+++ b/Resume.js
@@ -247,5 +247,33 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('video-modal');
+  const openBtn = document.querySelector('.video-demo');
+  if (!modal || !openBtn) return;
+  const closeBtn = modal.querySelector('.modal-close');
+
+  function openModal() {
+    modal.removeAttribute('hidden');
+    closeBtn.focus();
+  }
+
+  function closeModal() {
+    modal.setAttribute('hidden', '');
+    openBtn.focus();
+  }
+
+  openBtn.addEventListener('click', openModal);
+  closeBtn.addEventListener('click', closeModal);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) closeModal();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !modal.hasAttribute('hidden')) {
+      closeModal();
+    }
+  });
+});
+
 
 

--- a/index.html
+++ b/index.html
@@ -10,12 +10,14 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&family=Playfair+Display:ital,wght@1,600&display=swap"
     rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com?plugins=line-clamp"></script>
   <link rel="stylesheet" href="Resume.css">
 </head>
 
 <body>
   <nav class="navbar">
     <a href="#hero" class="nav-link active">Home</a>
+    <a href="#projects" class="nav-link">Projects</a>
     <a href="#card" class="nav-link">Contact</a>
     <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
   </nav>
@@ -80,9 +82,10 @@
         </div>
       </div>
     </div>
-  </section>
+    </section>
 
-  <!-- Education Section -->
+
+    <!-- Education Section -->
   <div class="education-section fade-section" id="education">
     <div class="content-container">
       <h2>Education</h2>
@@ -184,76 +187,28 @@
     </div>
   </section>
 
-  <section class="projects-section fade-section">
+  <section class="projects-section fade-section" id="projects">
     <div class="projects-container">
       <div class="projects-header">
-        <h2>My Projects</h2>
+        <div class="projects-header-row">
+          <h2>My Projects</h2>
+          <a href="/projects" class="see-more">See more →</a>
+        </div>
         <p>Explore some of the projects I've built</p>
       </div>
 
-      <div class="projects-grid">
-        <div class="project-card" data-project="project1">
-          <div class="project-card-header">
-            <h3>Memory Game</h3>
-            <span class="project-date">May 2024</span>
-          </div>
-          <div class="project-location">🍁 NL, Canada</div>
-          <div class="project-description">
-            <p>An interactive web-based memory game built with React and Vite, featuring optimized performance and
-              modern UI design.</p>
-          </div>
-          <div class="project-tech">
-            <span class="tech-tag">React</span>
-            <span class="tech-tag">Vite</span>
-            <span class="tech-tag">JavaScript</span>
-            <span class="tech-tag">Vercel</span>
-          </div>
-          <ul class="project-details">
-            <li>Developed an interactive web-based memory game using React and Vite</li>
-            <li>Implemented state management with custom React hooks</li>
-            <li>Deployed on Vercel with CI/CD pipeline</li>
-            <li>Features card flipping animations, score tracking and timer</li>
-            <li>Responsive design for desktop and mobile</li>
-          </ul>
-          <div class="project-actions">
-            <a href="https://card-memory-game-gold.vercel.app/" target="_blank" class="project-link">
-              <span>🔗</span> Live Demo
-            </a>
-          </div>
-        </div>
-
-        <div class="project-card" data-project="project2">
-          <div class="project-card-header">
-            <h3>CV Maker</h3>
-            <span class="project-date">April 2024</span>
-          </div>
-          <div class="project-location">🍁 NL, Canada</div>
-          <div class="project-description">
-            <p>A full-stack resume builder with PDF export, drag-and-drop functionality, and multiple template designs.
-            </p>
-          </div>
-          <div class="project-tech">
-            <span class="tech-tag">React</span>
-            <span class="tech-tag">react-pdf</span>
-            <span class="tech-tag">react-beautiful-dnd</span>
-            <span class="tech-tag">CSS</span>
-          </div>
-          <ul class="project-details">
-            <li>Full-stack resume builder with PDF export using react-pdf</li>
-            <li>Drag-and-drop interface with react-beautiful-dnd</li>
-            <li>Auto-save feature and multiple templates</li>
-            <li>40% faster renders with React optimizations</li>
-          </ul>
-          <div class="project-actions">
-            <a href="https://cv-builder-noureldeen.vercel.app/" target="_blank" class="project-link">
-              <span>🔗</span> Live Demo
-            </a>
-          </div>
-        </div>
-      </div>
+      <div id="projects-root" data-limit="4"></div>
     </div>
   </section>
 
+
+  <div class="modal" id="video-modal" role="dialog" aria-modal="true" aria-labelledby="video-modal-title" hidden>
+    <div class="modal-content">
+      <h3 id="video-modal-title">No public live demo</h3>
+      <p>Contact for private video link.</p>
+      <button type="button" class="modal-close" aria-label="Close">Close</button>
+    </div>
+  </div>
 
   <!-- Skills section moved after projects -->
   <section class="skills-main-section fade-section">
@@ -614,6 +569,10 @@
 
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="projects.js"></script>
   <script src="Resume.js"></script>
 </body>
 

--- a/projects.js
+++ b/projects.js
@@ -1,0 +1,119 @@
+const PROJECTS = [
+  {
+    title: "Memory Game",
+    location: "NL, Canada",
+    date: "May 2024",
+    description: "An interactive, web-based memory game built with React and Vite, designed to deliver a smooth, engaging user experience across desktop and mobile. The project emphasizes performance optimization, modern UI/UX practices, and scalable deployment.",
+    tags: ['React','Vite','JavaScript','Vercel'],
+    highlights: [
+      "Card-flipping game with scoring, timer, and difficulty scaling",
+      "Custom React hooks for state management",
+      "CI/CD deployment pipeline via Vercel",
+      "60fps animations and optimized rendering",
+      "Fully responsive design",
+      "Modular architecture for extensibility"
+    ],
+    cta: { type: 'live', label: 'Live Demo', href: 'https://card-memory-game-gold.vercel.app/' }
+  },
+  {
+    title: "CV Maker (AI-Powered Resume Builder)",
+    location: "NL, Canada",
+    date: "April 2024",
+    description: "A full-stack, AI-assisted resume builder designed for professionals and students. The platform enables users to create, edit, and export resumes with intelligent suggestions, drag-and-drop customization, and multi-template support.",
+    tags: ['React','react-pdf','react-beautiful-dnd','CSS','AI'],
+    highlights: [
+      "AI-assisted phrasing and keyword suggestions",
+      "Full-stack builder with live editing and PDF export",
+      "Drag-and-drop section reordering with react-beautiful-dnd",
+      "Auto-save with local and cloud storage",
+      "Multi-template designs with optimized performance",
+      "40% faster render times and pixel-perfect PDFs"
+    ],
+    cta: { type: 'live', label: 'Live Demo', href: 'https://cv-builder-noureldeen.vercel.app/' }
+  },
+  {
+    title: "JobDone",
+    location: "NL, Canada",
+    date: "April 2024",
+    description: "A Flutter marketplace app where customers post jobs and verified fixers submit offers. Built with Firebase for auth, real-time chat, and scalable data; includes a Google Maps experience and role-based dashboards.",
+    tags: ['Flutter','Dart','Firebase','Google Maps'],
+    highlights: [
+      "Post/manage jobs with images, budgets, date & time windows",
+      "Fixers submit offers with pricing and availability",
+      "Real-time 1:1 messaging",
+      "Map view of nearby jobs (bottom-sheet details)",
+      "Document & selfie verification"
+    ],
+    cta: { type: 'video', label: 'Video demo available' }
+  },
+  {
+    title: "World Population & Satellite Data Analysis",
+    location: "NL, Canada",
+    date: "May 2025",
+    description: "A comprehensive data analytics project leveraging global satellite catalog data and 2023 world population statistics to uncover trends in space activity. Delivered as two Jupyter notebooks showcasing a full exploratory workflow and a final polished analysis.",
+    tags: ['Python','Pandas','Plotly','Matplotlib','Seaborn','Jupyter'],
+    highlights: [
+      "Designed and executed an end-to-end data analysis pipeline for satellite activity",
+      "Preprocessed and normalized satellite and population datasets for consistency",
+      "Built advanced visualizations (time series, orbit distribution, waffle, circle-packing)",
+      "Conducted per-capita analysis to highlight country-level contributions relative to population size",
+      "Produced both exploratory (EDA) and presentation-ready deliverables with actionable insights"
+    ],
+    cta: { type: 'notebooks', label: 'Delivered as Jupyter Notebooks — no live demo' }
+  }
+];
+
+function ProjectCard({ title, location, date, description, tags, highlights, cta }) {
+  return (
+    <div className="flex flex-col h-full p-6 rounded-2xl bg-zinc-900/70 border border-zinc-800 shadow transition-transform brightness-90 hover:brightness-100 active:brightness-110 hover:-translate-y-1 active:translate-y-0">
+      <div className="flex items-start justify-between gap-3 min-h-[56px]">
+        <h3 className="text-xl font-semibold leading-tight max-w-[70%] truncate">{title}</h3>
+        <span className="px-3 py-1 rounded-full bg-blue-600/20 text-blue-300 text-sm whitespace-nowrap leading-none">{date}</span>
+      </div>
+      <p className="mt-1 text-sm text-zinc-400">{location}</p>
+      <p className="mt-3 text-zinc-200 line-clamp-3">{description}</p>
+      <ul className="mt-3 flex flex-wrap gap-2">
+        {tags.map(t => (
+          <li key={t} className="px-3 py-1 rounded-full bg-zinc-800 text-zinc-200 text-sm">{t}</li>
+        ))}
+      </ul>
+      <ul className="mt-4 space-y-1 text-zinc-200 text-sm">
+        {highlights.map((h,i) => (
+          <li key={i} className="list-disc ml-5">{h}</li>
+        ))}
+      </ul>
+      <div className="mt-auto">
+        <div className="mt-5">
+          {cta.type === 'live' && (
+            <a className="inline-flex items-center px-4 py-2 rounded-full bg-blue-600 hover:bg-blue-500 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" href={cta.href} target="_blank" rel="noopener noreferrer" aria-label={cta.label}>{cta.label}</a>
+          )}
+          {cta.type === 'video' && (
+            cta.href ? (
+              <a className="inline-flex items-center px-4 py-2 rounded-full border border-zinc-600 text-zinc-100 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-400" href={cta.href} aria-label={cta.label}>{cta.label}</a>
+            ) : (
+              <button type="button" className="inline-flex items-center px-4 py-2 rounded-full border border-zinc-600 text-zinc-100 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-400 video-demo" aria-haspopup="dialog" aria-controls="video-modal" aria-label={cta.label}>{cta.label}</button>
+            )
+          )}
+          {cta.type === 'notebooks' && (
+            <span className="inline-flex items-center px-3 py-1 rounded-full bg-zinc-800 text-zinc-300 text-sm">{cta.label}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectsGrid({ limit }) {
+  const list = typeof limit === 'number' ? PROJECTS.slice(0, limit) : PROJECTS;
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {list.map(p => <ProjectCard key={p.title} {...p} />)}
+    </div>
+  );
+}
+
+const rootEl = document.getElementById('projects-root');
+if (rootEl) {
+  const limit = rootEl.dataset.limit ? parseInt(rootEl.dataset.limit, 10) : undefined;
+  ReactDOM.createRoot(rootEl).render(<ProjectsGrid limit={limit} />);
+}

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projects</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Inter:wght@400;500&family=Poppins:wght@500;600;700&family=Playfair+Display:ital,wght@1,600&display=swap"
+    rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com?plugins=line-clamp"></script>
+  <link rel="stylesheet" href="../Resume.css">
+</head>
+
+<body>
+  <nav class="navbar">
+    <a href="/" class="nav-link">Home</a>
+    <a href="/projects" class="nav-link active">Projects</a>
+    <a href="/index.html#card" class="nav-link">Contact</a>
+    <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+  </nav>
+
+  <section class="projects-section fade-section" id="projects">
+    <div class="projects-container">
+      <div class="projects-header">
+        <h2>My Projects</h2>
+        <p>Explore some of the projects I've built</p>
+      </div>
+
+      <div id="projects-root"></div>
+    </div>
+  </section>
+
+  <div class="modal" id="video-modal" role="dialog" aria-modal="true" aria-labelledby="video-modal-title" hidden>
+    <div class="modal-content">
+      <h3 id="video-modal-title">No public live demo</h3>
+      <p>Contact for private video link.</p>
+      <button type="button" class="modal-close" aria-label="Close">Close</button>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="../projects.js"></script>
+  <script src="../Resume.js"></script>
+</body>
+
+</html>
+


### PR DESCRIPTION
## Summary
- introduce a reusable `<ProjectCard/>` React component with clamped descriptions, tag pills, highlight bullets, and CTA variants
- render home and /projects pages from shared project data, limiting the landing page to four cards
- drop obsolete project CSS in favor of Tailwind utilities and responsive 1‑col/2‑col grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9622e0e08332ac1562d99f56e32f